### PR TITLE
chore: release prep — badges, CHANGELOG-based release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -203,6 +203,13 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          NOTES=$(awk "/^## \\[${VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found{print}" CHANGELOG.md)
+          echo "$NOTES" > /tmp/release_notes.md
+
       - name: Download CLI artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -221,5 +228,5 @@ jobs:
         run: |
           gh release create "$GITHUB_REF_NAME" \
             --title "$GITHUB_REF_NAME" \
-            --generate-notes \
+            --notes-file /tmp/release_notes.md \
             dist/*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # ztraj
 
+[![CI](https://github.com/N283T/ztraj/actions/workflows/ci.yml/badge.svg)](https://github.com/N283T/ztraj/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/pyztraj)](https://pypi.org/project/pyztraj/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 High-performance molecular dynamics trajectory analysis library and CLI, written in Zig with Python bindings.
 
 ## Features


### PR DESCRIPTION
## Summary

- Add CI / PyPI / License badges to README
- Switch GitHub Release notes from `--generate-notes` to CHANGELOG.md extraction

## Pre-release checklist
- [x] Version 0.1.0 consistent across: build.zig, build.zig.zon, pyproject.toml, c_api.zig
- [x] CHANGELOG finalized for 0.1.0
- [x] LICENSE file exists
- [x] PyPI Trusted Publisher configured (pypi + testpypi environments)
- [x] publish.yml environment names match PyPI config
- [x] Release notes extracted from CHANGELOG

## Test plan
- [x] CI passes