### PR TITLE
ci: optimize paths-ignore, always run CI on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,17 +4,14 @@ on:
   push:
     branches: [main]
     paths-ignore:
-      - '*.md'
+      - '**.md'
       - 'docs/**'
       - 'plans/**'
       - 'LICENSE'
+      - '.gitignore'
+      - '.github/workflows/publish.yml'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '*.md'
-      - 'docs/**'
-      - 'plans/**'
-      - 'LICENSE'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

- Push to main: skip CI for docs-only changes (.md, .gitignore, LICENSE, publish.yml)
- PR: always run CI (required by branch protection — skipping would block merge)
- Use `**.md` to match markdown in subdirectories

## Test plan
- [x] CI runs on this PR (proves PR path works)