### PR TITLE
fix: skip i686 wheels (Zig has no 32-bit Linux)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -51,7 +51,7 @@ python-version = "3.11"
 
 [tool.cibuildwheel]
 build = ["cp311-*", "cp312-*", "cp313-*"]
-skip = ["*-win32", "*-win_arm64", "*-musllinux_*", "*_s390x", "*_ppc64le"]
+skip = ["*-win32", "*-win_arm64", "*-musllinux_*", "*_s390x", "*_ppc64le", "*_i686"]
 test-requires = ["pytest", "numpy"]
 test-command = "pytest {project}/python/tests -x -q"
 


### PR DESCRIPTION
cibuildwheel tried to build i686 wheels but Zig doesn't provide 32-bit Linux binaries (404). Add `*_i686` to skip list.