### PR TITLE
fix: pypi-publish action Docker image resolution

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -181,13 +181,13 @@ jobs:
 
       - name: Publish to PyPI
         if: github.event_name == 'push' || inputs.target == 'pypi'
-        uses: pypa/gh-action-pypi-publish@106e0b0b7c337fa67ed433972f777c6357f78598 # v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           packages-dir: dist/
 
       - name: Publish to TestPyPI
         if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
-        uses: pypa/gh-action-pypi-publish@106e0b0b7c337fa67ed433972f777c6357f78598 # v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           packages-dir: dist/
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Docker-based actions can't be pinned by SHA — the container image is only tagged, not SHA-indexed. Use v1.13.0 tag.