### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.2.0] - 2026-03-19
+
+### Added
+- SASA computation via zsasa dependency (Shrake-Rupley algorithm, element-based VdW radii)
+- `all` command: combined analysis (RMSD, RMSF, Rg, SASA, COM, hbonds, contacts) in one pass
+- Python `analyze_all()` convenience function for batch trajectory analysis
+- `compute_sasa()` Python API with per-atom and total SASA
+
+### Changed
+- Split monolithic `core.py` (1080 lines) into focused modules:
+  `_helpers.py`, `io.py`, `geometry.py`, `analysis.py`, `combined.py`
+- External Python API unchanged (all re-exported from `__init__.py`)
+
+### Fixed
+- PyPI publish action: use tag instead of SHA for Docker-based action
+
 ## [0.1.0] - 2026-03-18
 
 ### Added

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-const version = "0.1.0";
+const version = "0.2.0";
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0x17e956260cdc6d81,
     .name = .ztraj,
-    .version = "0.1.0",
+    .version = "0.2.0",
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .zxdrfile = .{

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyztraj"
-version = "0.1.0"
+version = "0.2.0"
 description = "Fast molecular dynamics trajectory analysis powered by Zig"
 readme = "README.md"
 license = "MIT"

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -43,7 +43,7 @@ pub const ZTRAJ_ERROR_EOF: c_int = -5;
 // Version
 // =============================================================================
 
-const VERSION: [*:0]const u8 = "0.1.0";
+const VERSION: [*:0]const u8 = "0.2.0";
 
 /// Get the library version string.
 export fn ztraj_version() callconv(.c) [*:0]const u8 {


### PR DESCRIPTION
## [0.2.0] - 2026-03-19

### Added
- SASA computation via zsasa dependency (Shrake-Rupley algorithm, element-based VdW radii)
- `all` command: combined analysis (RMSD, RMSF, Rg, SASA, COM, hbonds, contacts) in one pass
- Python `analyze_all()` convenience function for batch trajectory analysis
- `compute_sasa()` Python API with per-atom and total SASA

### Changed
- Split monolithic `core.py` (1080 lines) into focused modules
- External Python API unchanged

### Fixed
- PyPI publish action: use tag instead of SHA for Docker-based action

### Version bumped
- build.zig, build.zig.zon, pyproject.toml, c_api.zig: 0.1.0 → 0.2.0