### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [0.3.0] - 2026-03-21
+
+### Added
+- Native DSSP secondary structure assignment (replaced vendored zdssp)
+- Protein-specific dihedrals: phi, psi, omega, chi1-chi4 CLI commands
+- Structural superposition (QCP-based optimal alignment with `Frame.initView`)
+- PBC support: wrap coordinates, minimum image distance, make molecules whole
+- TRR trajectory format support (GROMACS)
+- Native contacts Q value (hard-cut and soft-cut)
+- MSD (Mean Square Displacement) for diffusion analysis
+- PCA (Principal Component Analysis) of coordinate fluctuations
+- Validation suite expanded to 14 tests (pytest-based, vs mdtraj references)
+  - Added phi/psi, superposition, PBC distance, DSSP, SASA validations
+- `Frame.initView()` for safe non-owning views over const coordinate slices
+
+### Changed
+- DSSP: native implementation using ztraj types (atom indices into Frame)
+  instead of vendored zdssp copy (removed 9058 lines)
+- Validation suite moved from PEP 723 script to pytest
+- Python `_pack_frames` helper extracted to eliminate 3× duplication
+- CI validation job uses pytest instead of standalone script
+
+### Fixed
+- Superposition S matrix convention (was transposed vs rmsd.zig)
+- PBC box validation (reject zero/negative diagonals)
+- PCA dimension overflow guard (reject dim > 30,000)
+- Native contacts bounds check on atom indices
+- `@constCast` eliminated from C API via `Frame.initView()`
+
 ## [0.2.0] - 2026-03-19
 
 ### Added

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-const version = "0.2.0";
+const version = "0.3.0";
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0x17e956260cdc6d81,
     .name = .ztraj,
-    .version = "0.2.0",
+    .version = "0.3.0",
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .zxdrfile = .{

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyztraj"
-version = "0.2.0"
+version = "0.3.0"
 description = "Fast molecular dynamics trajectory analysis powered by Zig"
 readme = "README.md"
 license = "MIT"

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -47,7 +47,7 @@ pub const ZTRAJ_ERROR_EOF: c_int = -5;
 // Version
 // =============================================================================
 
-const VERSION: [*:0]const u8 = "0.2.0";
+const VERSION: [*:0]const u8 = "0.3.0";
 
 /// Get the library version string.
 export fn ztraj_version() callconv(.c) [*:0]const u8 {


### PR DESCRIPTION
## [0.3.0] - 2026-03-21

### Added
- Native DSSP (replaced 9058-line vendored copy with 2516-line native impl)
- Protein dihedrals: phi, psi, omega, chi1-chi4
- Superposition (QCP optimal alignment)
- PBC: wrap, minimum image, make molecules whole
- TRR format, Native contacts Q, MSD, PCA
- 14 validation tests (pytest, vs mdtraj)
- `Frame.initView()` for const-safe C API

### Changed
- Validation suite → pytest
- `_pack_frames` helper (3× dedup)

### Fixed
- S matrix convention in superpose
- PBC box validation, PCA dim guard
- `@constCast` eliminated from C API

### Version bumped
- 0.2.0 → 0.3.0 in build.zig, build.zig.zon, pyproject.toml, c_api.zig