### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.6.0] - 2026-03-29
+
+### Added
+- #78 Interactive marimo notebook for trajectory analysis
+- #88 CLAUDE.md with project conventions and build instructions
+
+### Fixed
+- #79 Infer D-H bonds when topology lacks bond records
+- #85 Address review findings across CLI, FFI, packaging, and CI
+  - Extract duplicate validation helpers to shared module
+  - Replace `std.process.exit(1)` with proper error returns
+  - Add `n_atoms` validation to C API dihedral/DSSP exports
+  - Fix contacts reallocation path
+  - Add Windows CI support
+  - Tighten publish workflow tag pattern
+- #87 Handle DSSP compute errors individually instead of catch-all
+
 ## [0.5.1] - 2026-03-26
 
 ### Added

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-const version = "0.5.1";
+const version = "0.6.0";
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0x17e956260cdc6d81,
     .name = .ztraj,
-    .version = "0.5.1",
+    .version = "0.6.0",
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .zxdrfile = .{

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyztraj"
-version = "0.5.1"
+version = "0.6.0"
 description = "Fast molecular dynamics trajectory analysis powered by Zig"
 readme = "README.md"
 license = "MIT"

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -55,7 +55,7 @@ pub const ZTRAJ_ERROR_EOF: c_int = -5;
 // Version
 // =============================================================================
 
-const VERSION: [*:0]const u8 = "0.5.1";
+const VERSION: [*:0]const u8 = "0.6.0";
 
 /// Get the library version string.
 export fn ztraj_version() callconv(.c) [*:0]const u8 {


### PR DESCRIPTION
## [0.6.0] - 2026-03-29

### Added
- #78 Interactive marimo notebook for trajectory analysis
- #88 CLAUDE.md with project conventions and build instructions

### Fixed
- #79 Infer D-H bonds when topology lacks bond records
- #85 Address review findings across CLI, FFI, packaging, and CI
- #87 Handle DSSP compute errors individually instead of catch-all

### Version bumped in
- `build.zig` (0.5.1 → 0.6.0)
- `build.zig.zon` (0.5.1 → 0.6.0)
- `src/c_api.zig` (0.5.1 → 0.6.0)
- `python/pyproject.toml` (0.5.1 → 0.6.0)