### PR TITLE
release: v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.6.1] - 2026-04-13
+
+### Added
+- #90 AMBER PRMTOP topology parser (.prmtop, .parm7, .top)
+  - Atom names, residues, bonds, partial charges, force-field masses
+  - ATOMIC_NUMBER element assignment (amber12+) with fallback heuristic
+  - Chamber-style topology detection with clear error
+- #91 AMBER NetCDF trajectory reader (.nc, .ncdf)
+  - NetCDF-3 classic and 64-bit offset format (no external dependency)
+  - Streaming NcReader API matching XtcReader/DcdReader/TrrReader pattern
+  - Coordinates, time, cell_lengths/cell_angles with triclinic box conversion
+- #93 Python bindings for AMBER formats
+  - `pyztraj.load_prmtop()`: topology loading with masses and charges
+  - `pyztraj.open_nc()` / `NcReader`: streaming NetCDF trajectory reader
+  - C API: `ztraj_load_prmtop`, `ztraj_open_nc`, `ztraj_read_nc_frame`, `ztraj_close_nc`
+
+### Changed
+- Topology gains optional `charges` and `explicit_masses` fields (null when absent)
+- `Topology.masses()` prefers explicit force-field masses over element-derived values
+- `Topology.validate()` checks charges/explicit_masses length consistency
+
+### Fixed
+- `ztraj_get_n_atoms` C API uses topology atom count (was frame count, returned 0 for topology-only formats)
+- Analysis C API functions validate n_atoms against topology (was frame, broke prmtop workflow)
+
 ## [0.6.0] - 2026-03-29
 
 ### Added

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-const version = "0.6.0";
+const version = "0.6.1";
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0x17e956260cdc6d81,
     .name = .ztraj,
-    .version = "0.6.0",
+    .version = "0.6.1",
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .zxdrfile = .{

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyztraj"
-version = "0.6.0"
+version = "0.6.1"
 description = "Fast molecular dynamics trajectory analysis powered by Zig"
 readme = "README.md"
 license = "MIT"

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -57,7 +57,7 @@ pub const ZTRAJ_ERROR_EOF: c_int = -5;
 // Version
 // =============================================================================
 
-const VERSION: [*:0]const u8 = "0.6.0";
+const VERSION: [*:0]const u8 = "0.6.1";
 
 /// Get the library version string.
 export fn ztraj_version() callconv(.c) [*:0]const u8 {


### PR DESCRIPTION
## [0.6.1] - 2026-04-13

### Added
- #90 AMBER PRMTOP topology parser (.prmtop, .parm7, .top)
- #91 AMBER NetCDF trajectory reader (.nc, .ncdf)
- #93 Python bindings for AMBER formats (`load_prmtop`, `open_nc`, `NcReader`)

### Changed
- Topology gains optional `charges` and `explicit_masses` fields
- `Topology.masses()` prefers explicit force-field masses over element-derived values

### Fixed
- `ztraj_get_n_atoms` C API uses topology atom count (was frame count)
- Analysis C API functions validate against topology (was frame)