### PR TITLE
release: v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.6.1] - 2026-04-13
+## [0.6.2] - 2026-04-13
 
 ### Added
 - #90 AMBER PRMTOP topology parser (.prmtop, .parm7, .top)

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-const version = "0.6.1";
+const version = "0.6.2";
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0x17e956260cdc6d81,
     .name = .ztraj,
-    .version = "0.6.1",
+    .version = "0.6.2",
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .zxdrfile = .{

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyztraj"
-version = "0.6.1"
+version = "0.6.2"
 description = "Fast molecular dynamics trajectory analysis powered by Zig"
 readme = "README.md"
 license = "MIT"

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -57,7 +57,7 @@ pub const ZTRAJ_ERROR_EOF: c_int = -5;
 // Version
 // =============================================================================
 
-const VERSION: [*:0]const u8 = "0.6.1";
+const VERSION: [*:0]const u8 = "0.6.2";
 
 /// Get the library version string.
 export fn ztraj_version() callconv(.c) [*:0]const u8 {


### PR DESCRIPTION
## [0.6.2] - 2026-04-13

Re-release of v0.6.1 content (PyPI rejected v0.6.1 re-upload after tag recreation).

### Added
- #90 AMBER PRMTOP topology parser (.prmtop, .parm7, .top)
- #91 AMBER NetCDF trajectory reader (.nc, .ncdf)
- #93 Python bindings for AMBER formats
- #95 Self-generated test data (license-clean)
- #96 AMBER NetCDF trajectory writer

### Changed
- Topology gains optional `charges` and `explicit_masses` fields
- `Topology.masses()` prefers explicit FF masses over element-derived

### Fixed
- `ztraj_get_n_atoms` / analysis C API: use topology atom count