### PR TITLE
chore: migrate to Zig 0.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Check formatting
         run: zig fmt --check src/
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Run tests
         run: zig build test
@@ -107,7 +107,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Build shared library
         run: zig build -Doptimize=ReleaseFast
@@ -174,7 +174,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Build shared library
         run: zig build -Doptimize=ReleaseFast
@@ -208,7 +208,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
         if: runner.os != 'Linux'
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Cache cibuildwheel
         if: runner.os != 'Linux'
@@ -123,7 +123,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Build CLI
         run: zig build -Doptimize=ReleaseFast

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/N283T/ztraj/actions/workflows/ci.yml/badge.svg)](https://github.com/N283T/ztraj/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/pyztraj)](https://pypi.org/project/pyztraj/)
-[![Zig](https://img.shields.io/badge/Zig-0.15.2-f7a41d?logo=zig)](https://ziglang.org/)
+[![Zig](https://img.shields.io/badge/Zig-0.16.0-f7a41d?logo=zig)](https://ziglang.org/)
 [![Python](https://img.shields.io/pypi/pyversions/pyztraj)](https://pypi.org/project/pyztraj/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
@@ -22,7 +22,7 @@ High-performance molecular dynamics trajectory analysis library and CLI, written
 # Install from PyPI (no Zig required)
 uv tool install pyztraj
 
-# Or build from source (requires Zig 0.15.2+)
+# Or build from source (requires Zig 0.16.0+)
 zig build -Doptimize=ReleaseFast
 ```
 
@@ -127,7 +127,7 @@ r, g_r = pyztraj.compute_rdf(sel1_coords, sel2_coords, box_volume=1000.0)
 
 ## Building from source
 
-Requires [Zig 0.15.2+](https://ziglang.org/download/).
+Requires [Zig 0.16.0+](https://ziglang.org/download/).
 
 ```bash
 # Build CLI + shared library

--- a/build.zig
+++ b/build.zig
@@ -36,13 +36,13 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/c_api.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
             .imports = &.{
                 .{ .name = "zxdrfile", .module = zxdrfile_mod },
                 .{ .name = "zsasa", .module = zsasa_mod },
             },
         }),
     });
-    lib.linkLibC();
     b.installArtifact(lib);
 
     // CLI executable

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,15 +2,15 @@
     .fingerprint = 0x17e956260cdc6d81,
     .name = .ztraj,
     .version = "0.6.2",
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .zxdrfile = .{
-            .url = "git+https://github.com/N283T/zxdrfile.git?ref=v0.2.0#4f6b7853efc747a3ac7d7c94bb4302114b12c916",
-            .hash = "zxdrfile-0.2.0-JIaQ9hMJAgCg3RxOMkEd_n0mQX_MBry33wBKhZ7I1kwm",
+            .url = "git+https://github.com/N283T/zxdrfile.git?ref=v0.4.0#47d8c42cff9b098febd1990cc50438c26987f85c",
+            .hash = "zxdrfile-0.4.0-JIaQ9mIfAgAHB9bW-_p9g6_gfd0tyG3-MmA0LYJKB8rb",
         },
         .zsasa = .{
-            .url = "git+https://github.com/N283T/freesasa-zig.git#f76cafbf4f774531f291f8778552ba513bb03e5d",
-            .hash = "zsasa-0.2.4-d7uHxM_KDABCLaSpqZFoO6LCEY_z8oJQD6i_v5eAKGuK",
+            .url = "git+https://github.com/N283T/freesasa-zig.git?ref=v0.2.11#63a9241e965e3f0a9f79519cc9b10a8e431a5eaf",
+            .hash = "zsasa-0.2.11-d7uHxJFhEADTdAgq3DrcSPa2VBMVMZ0jR8Aacdf3cTwb",
         },
     },
     .paths = .{

--- a/src/analysis/contacts.zig
+++ b/src/analysis/contacts.zig
@@ -108,7 +108,7 @@ pub fn compute(
     scheme: Scheme,
     cutoff: f32,
 ) ![]Contact {
-    var result = std.ArrayList(Contact){};
+    var result = std.ArrayList(Contact).empty;
     errdefer result.deinit(allocator);
 
     const n_res = topology.residues.len;
@@ -230,7 +230,7 @@ pub fn computeParallel(
     const tl_lists = try allocator.alloc(std.ArrayList(Contact), thread_count);
     defer allocator.free(tl_lists);
     for (0..thread_count) |t| {
-        tl_lists[t] = std.ArrayList(Contact){};
+        tl_lists[t] = std.ArrayList(Contact).empty;
     }
     defer for (0..thread_count) |t| {
         tl_lists[t].deinit(allocator);

--- a/src/analysis/hbonds.zig
+++ b/src/analysis/hbonds.zig
@@ -235,13 +235,13 @@ fn inferDHBonds(
     frame: types.Frame,
 ) ![]types.Bond {
     const n_atoms = topology.atoms.len;
-    var bonds = std.ArrayList(types.Bond){};
+    var bonds = std.ArrayList(types.Bond).empty;
     errdefer bonds.deinit(allocator);
 
     // Collect hydrogen indices and donor (N/O) indices.
-    var h_list = std.ArrayList(u32){};
+    var h_list = std.ArrayList(u32).empty;
     defer h_list.deinit(allocator);
-    var donor_list = std.ArrayList(u32){};
+    var donor_list = std.ArrayList(u32).empty;
     defer donor_list.deinit(allocator);
 
     for (0..n_atoms) |i| {
@@ -298,7 +298,7 @@ pub fn detect(
     frame: types.Frame,
     config: Config,
 ) ![]HBond {
-    var result = std.ArrayList(HBond){};
+    var result = std.ArrayList(HBond).empty;
     errdefer result.deinit(allocator);
 
     const n_atoms = topology.atoms.len;
@@ -579,7 +579,7 @@ pub fn detectParallel(
     const actual_threads = @min(n_threads, cpu_count);
 
     // Pre-scan bonds to collect D-H pairs.
-    var dh_list = std.ArrayList(DHBond){};
+    var dh_list = std.ArrayList(DHBond).empty;
     defer dh_list.deinit(allocator);
 
     for (topology.bonds) |bond| {
@@ -616,7 +616,7 @@ pub fn detectParallel(
     const tl_lists = try allocator.alloc(std.ArrayList(HBond), thread_count);
     defer allocator.free(tl_lists);
     for (0..thread_count) |t| {
-        tl_lists[t] = std.ArrayList(HBond){};
+        tl_lists[t] = std.ArrayList(HBond).empty;
     }
     defer for (0..thread_count) |t| {
         tl_lists[t].deinit(allocator);

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -74,6 +74,38 @@ const c_allocator = std.heap.c_allocator;
 const MAX_PDB_FILE_SIZE = 100 * 1024 * 1024;
 
 // =============================================================================
+// Process-global I/O instance for the C API
+// =============================================================================
+//
+// Python and other FFI consumers call the C API without a `main(init)` entry
+// point, so they cannot supply an `Io` themselves. We lazily construct a
+// shared `Io.Threaded` on first use and reuse it for the lifetime of the
+// process. We claim the right to initialize via a CAS on a state flag, then
+// race-losing threads spin until the winner finishes; in practice the Python
+// GIL serializes calls so contention is non-existent.
+
+const IoInitState = enum(u8) { uninit, initializing, ready };
+
+var io_threaded_storage: std.Io.Threaded = undefined;
+var io_threaded_state: std.atomic.Value(IoInitState) = .init(.uninit);
+
+fn getIo() std.Io {
+    while (true) {
+        switch (io_threaded_state.load(.acquire)) {
+            .ready => return io_threaded_storage.io(),
+            .initializing => std.Thread.yield() catch {},
+            .uninit => {
+                if (io_threaded_state.cmpxchgStrong(.uninit, .initializing, .acq_rel, .acquire) == null) {
+                    io_threaded_storage = std.Io.Threaded.init(c_allocator, .{});
+                    io_threaded_state.store(.ready, .release);
+                    return io_threaded_storage.io();
+                }
+            },
+        }
+    }
+}
+
+// =============================================================================
 // Geometry: Distances
 // =============================================================================
 
@@ -517,7 +549,7 @@ export fn ztraj_load_pdb(
 
     // Read file
     const path_slice = std.mem.sliceTo(path, 0);
-    const data = std.fs.cwd().readFileAlloc(c_allocator, path_slice, MAX_PDB_FILE_SIZE) catch {
+    const data = std.Io.Dir.cwd().readFileAlloc(getIo(), path_slice, c_allocator, .limited(MAX_PDB_FILE_SIZE)) catch {
         return ZTRAJ_ERROR_FILE_IO;
     };
     defer c_allocator.free(data);
@@ -655,7 +687,7 @@ export fn ztraj_load_gro(
     handle_out.* = null;
 
     const path_slice = std.mem.sliceTo(path, 0);
-    const data = std.fs.cwd().readFileAlloc(c_allocator, path_slice, MAX_PDB_FILE_SIZE) catch {
+    const data = std.Io.Dir.cwd().readFileAlloc(getIo(), path_slice, c_allocator, .limited(MAX_PDB_FILE_SIZE)) catch {
         return ZTRAJ_ERROR_FILE_IO;
     };
     defer c_allocator.free(data);
@@ -694,7 +726,7 @@ export fn ztraj_load_mmcif(
     handle_out.* = null;
 
     const path_slice = std.mem.sliceTo(path, 0);
-    const data = std.fs.cwd().readFileAlloc(c_allocator, path_slice, MAX_PDB_FILE_SIZE) catch {
+    const data = std.Io.Dir.cwd().readFileAlloc(getIo(), path_slice, c_allocator, .limited(MAX_PDB_FILE_SIZE)) catch {
         return ZTRAJ_ERROR_FILE_IO;
     };
     defer c_allocator.free(data);
@@ -734,7 +766,7 @@ export fn ztraj_load_prmtop(
     handle_out.* = null;
 
     const path_slice = std.mem.sliceTo(path, 0);
-    const data = std.fs.cwd().readFileAlloc(c_allocator, path_slice, MAX_PDB_FILE_SIZE) catch {
+    const data = std.Io.Dir.cwd().readFileAlloc(getIo(), path_slice, c_allocator, .limited(MAX_PDB_FILE_SIZE)) catch {
         return ZTRAJ_ERROR_FILE_IO;
     };
     defer c_allocator.free(data);
@@ -807,7 +839,7 @@ export fn ztraj_open_xtc(
     handle_out.* = null;
 
     const path_slice = std.mem.sliceTo(path, 0);
-    var reader = xtc_mod.XtcReader.open(c_allocator, path_slice) catch {
+    var reader = xtc_mod.XtcReader.open(getIo(), c_allocator, path_slice) catch {
         return ZTRAJ_ERROR_FILE_IO;
     };
     errdefer reader.deinit();
@@ -905,7 +937,7 @@ export fn ztraj_open_trr(
     handle_out.* = null;
 
     const path_slice = std.mem.sliceTo(path, 0);
-    var reader = trr_mod.TrrReader.open(c_allocator, path_slice) catch |err| {
+    var reader = trr_mod.TrrReader.open(getIo(), c_allocator, path_slice) catch |err| {
         return switch (err) {
             trr_mod.TrrReadError.FileNotFound => ZTRAJ_ERROR_FILE_IO,
             trr_mod.TrrReadError.InvalidMagic, trr_mod.TrrReadError.InvalidHeader => ZTRAJ_ERROR_PARSE,
@@ -1009,7 +1041,7 @@ export fn ztraj_open_dcd(
     handle_out.* = null;
 
     const path_slice = std.mem.sliceTo(path, 0);
-    var reader = dcd_mod.DcdReader.open(c_allocator, path_slice) catch |err| {
+    var reader = dcd_mod.DcdReader.open(getIo(), c_allocator, path_slice) catch |err| {
         return switch (err) {
             dcd_mod.DcdError.FileNotFound => ZTRAJ_ERROR_FILE_IO,
             dcd_mod.DcdError.InvalidMagic, dcd_mod.DcdError.BadFormat => ZTRAJ_ERROR_PARSE,
@@ -1112,7 +1144,7 @@ export fn ztraj_open_nc(
     handle_out.* = null;
 
     const path_slice = std.mem.sliceTo(path, 0);
-    var reader = nc_mod.NcReader.open(c_allocator, path_slice) catch |err| {
+    var reader = nc_mod.NcReader.open(getIo(), c_allocator, path_slice) catch |err| {
         return switch (err) {
             nc_mod.NcError.FileNotFound => ZTRAJ_ERROR_FILE_IO,
             nc_mod.NcError.InvalidMagic,
@@ -1861,18 +1893,19 @@ export fn ztraj_write_pdb(
     if (n_atoms != topo.atoms.len) return ZTRAJ_ERROR_INVALID_INPUT;
     const frame = types.Frame.initView(x[0..n_atoms], y[0..n_atoms], z[0..n_atoms]);
 
+    const io = getIo();
     const path_slice = std.mem.sliceTo(path, 0);
-    const file = std.fs.cwd().createFile(path_slice, .{}) catch {
+    const file = std.Io.Dir.cwd().createFile(io, path_slice, .{}) catch {
         return ZTRAJ_ERROR_FILE_IO;
     };
-    defer file.close();
+    defer file.close(io);
 
-    var buf = std.ArrayListUnmanaged(u8){};
-    defer buf.deinit(c_allocator);
-    pdb_mod.write(buf.writer(c_allocator), topo, frame) catch |err| {
+    var aw: std.Io.Writer.Allocating = .init(c_allocator);
+    defer aw.deinit();
+    pdb_mod.write(&aw.writer, topo, frame) catch |err| {
         return if (err == error.OutOfMemory) ZTRAJ_ERROR_OUT_OF_MEMORY else ZTRAJ_ERROR_FILE_IO;
     };
-    file.writeAll(buf.items) catch {
+    file.writeStreamingAll(io, aw.written()) catch {
         return ZTRAJ_ERROR_FILE_IO;
     };
 
@@ -1896,18 +1929,19 @@ export fn ztraj_write_gro(
     if (n_atoms != topo.atoms.len) return ZTRAJ_ERROR_INVALID_INPUT;
     const frame = types.Frame.initView(x[0..n_atoms], y[0..n_atoms], z[0..n_atoms]);
 
+    const io = getIo();
     const path_slice = std.mem.sliceTo(path, 0);
-    const file = std.fs.cwd().createFile(path_slice, .{}) catch {
+    const file = std.Io.Dir.cwd().createFile(io, path_slice, .{}) catch {
         return ZTRAJ_ERROR_FILE_IO;
     };
-    defer file.close();
+    defer file.close(io);
 
-    var buf = std.ArrayListUnmanaged(u8){};
-    defer buf.deinit(c_allocator);
-    gro_mod.write(buf.writer(c_allocator), topo, frame) catch |err| {
+    var aw: std.Io.Writer.Allocating = .init(c_allocator);
+    defer aw.deinit();
+    gro_mod.write(&aw.writer, topo, frame) catch |err| {
         return if (err == error.OutOfMemory) ZTRAJ_ERROR_OUT_OF_MEMORY else ZTRAJ_ERROR_FILE_IO;
     };
-    file.writeAll(buf.items) catch {
+    file.writeStreamingAll(io, aw.written()) catch {
         return ZTRAJ_ERROR_FILE_IO;
     };
 
@@ -1951,7 +1985,7 @@ export fn ztraj_open_xtc_writer(
     handle_out.* = null;
     const path_slice = std.mem.sliceTo(path, 0);
 
-    var writer = xtc_mod.XtcWriter.open(c_allocator, path_slice, n_atoms) catch {
+    var writer = xtc_mod.XtcWriter.open(getIo(), c_allocator, path_slice, n_atoms) catch {
         return ZTRAJ_ERROR_FILE_IO;
     };
     errdefer writer.deinit();
@@ -2038,7 +2072,7 @@ export fn ztraj_open_trr_writer(
     handle_out.* = null;
     const path_slice = std.mem.sliceTo(path, 0);
 
-    var writer = trr_mod.TrrWriter.open(c_allocator, path_slice, n_atoms) catch {
+    var writer = trr_mod.TrrWriter.open(getIo(), c_allocator, path_slice, n_atoms) catch {
         return ZTRAJ_ERROR_FILE_IO;
     };
     errdefer writer.deinit();
@@ -2126,7 +2160,7 @@ export fn ztraj_open_nc_writer(
     handle_out.* = null;
     const path_slice = std.mem.sliceTo(path, 0);
 
-    var writer = nc_mod.NcWriter.open(c_allocator, path_slice, n_atoms, has_cell) catch {
+    var writer = nc_mod.NcWriter.open(getIo(), c_allocator, path_slice, n_atoms, has_cell) catch {
         return ZTRAJ_ERROR_FILE_IO;
     };
     errdefer writer.deinit();

--- a/src/cli/loader.zig
+++ b/src/cli/loader.zig
@@ -4,10 +4,10 @@ const std = @import("std");
 const ztraj = @import("ztraj");
 
 const types = ztraj.types;
-const io = ztraj.io;
+const trajio = ztraj.io;
 
-fn printStderr(msg: []const u8) void {
-    std.fs.File.stderr().writeAll(msg) catch {};
+fn printStderr(io: std.Io, msg: []const u8) void {
+    std.Io.File.stderr().writeStreamingAll(io, msg) catch {};
 }
 
 // ============================================================================
@@ -62,19 +62,19 @@ pub fn isNc(path: []const u8) bool {
 /// Load topology + first frame from a structure or topology file.
 /// Supported formats: PDB, CIF/mmCIF, GRO, PRMTOP/PARM7.
 /// Returns a ParseResult; caller must call .deinit().
-pub fn loadTopology(allocator: std.mem.Allocator, path: []const u8) !types.ParseResult {
-    const data = try std.fs.cwd().readFileAlloc(allocator, path, 512 * 1024 * 1024);
+pub fn loadTopology(io_handle: std.Io, allocator: std.mem.Allocator, path: []const u8) !types.ParseResult {
+    const data = try std.Io.Dir.cwd().readFileAlloc(io_handle, path, allocator, .limited(512 * 1024 * 1024));
     defer allocator.free(data);
 
     if (isPdb(path)) {
-        return io.pdb.parse(allocator, data);
+        return trajio.pdb.parse(allocator, data);
     } else if (isCif(path)) {
-        return io.mmcif.parse(allocator, data);
+        return trajio.mmcif.parse(allocator, data);
     } else if (isGro(path)) {
-        return io.gro.parse(allocator, data);
+        return trajio.gro.parse(allocator, data);
     } else if (isPrmtop(path)) {
         // PRMTOP is topology-only — wrap in ParseResult with a zero-atom frame
-        const topo = try io.prmtop.parseTopology(allocator, data);
+        const topo = try trajio.prmtop.parseTopology(allocator, data);
         errdefer {
             var t = topo;
             t.deinit();
@@ -83,7 +83,7 @@ pub fn loadTopology(allocator: std.mem.Allocator, path: []const u8) !types.Parse
         errdefer frame.deinit();
         return types.ParseResult{ .topology = topo, .frame = frame };
     } else {
-        printStderr("error: unsupported topology format (supported: .pdb, .cif, .mmcif, .gro, .prmtop, .parm7, .top)\n");
+        printStderr(io_handle, "error: unsupported topology format (supported: .pdb, .cif, .mmcif, .gro, .prmtop, .parm7, .top)\n");
         return error.UnsupportedFormat;
     }
 }
@@ -99,27 +99,28 @@ pub const TrajectoryInfo = struct {
     last_time: ?f32,
 };
 
-fn ensureAtomCount(path: []const u8, expected: usize, actual: usize) !void {
+fn ensureAtomCount(io_handle: std.Io, path: []const u8, expected: usize, actual: usize) !void {
     if (expected == actual) return;
 
     var buf: [256]u8 = undefined;
     const msg = std.fmt.bufPrint(&buf, "error: '{s}' has {d} atoms but topology expects {d}\n", .{ path, actual, expected }) catch
         "error: atom count mismatch between trajectory and topology\n";
-    printStderr(msg);
+    printStderr(io_handle, msg);
     return error.InvalidAtomCount;
 }
 
 /// Count frames and capture the first/last timestamps without materializing
 /// every frame in memory.
 pub fn loadTrajectoryInfo(
+    io_handle: std.Io,
     allocator: std.mem.Allocator,
     traj_path: []const u8,
     expected_n_atoms: ?usize,
 ) !TrajectoryInfo {
     if (isXtc(traj_path)) {
-        var reader = try io.xtc.XtcReader.open(allocator, traj_path);
+        var reader = try trajio.xtc.XtcReader.open(io_handle, allocator, traj_path);
         defer reader.deinit();
-        if (expected_n_atoms) |n_atoms| try ensureAtomCount(traj_path, n_atoms, reader.nAtoms());
+        if (expected_n_atoms) |n_atoms| try ensureAtomCount(io_handle, traj_path, n_atoms, reader.nAtoms());
 
         var n_frames: usize = 0;
         var first_time: ?f32 = null;
@@ -131,9 +132,9 @@ pub fn loadTrajectoryInfo(
         }
         return .{ .n_frames = n_frames, .first_time = first_time, .last_time = last_time };
     } else if (isDcd(traj_path)) {
-        var reader = try io.dcd.DcdReader.open(allocator, traj_path);
+        var reader = try trajio.dcd.DcdReader.open(io_handle, allocator, traj_path);
         defer reader.deinit();
-        if (expected_n_atoms) |n_atoms| try ensureAtomCount(traj_path, n_atoms, reader.nAtoms());
+        if (expected_n_atoms) |n_atoms| try ensureAtomCount(io_handle, traj_path, n_atoms, reader.nAtoms());
 
         var n_frames: usize = 0;
         var first_time: ?f32 = null;
@@ -145,9 +146,9 @@ pub fn loadTrajectoryInfo(
         }
         return .{ .n_frames = n_frames, .first_time = first_time, .last_time = last_time };
     } else if (isTrr(traj_path)) {
-        var reader = try io.trr.TrrReader.open(allocator, traj_path);
+        var reader = try trajio.trr.TrrReader.open(io_handle, allocator, traj_path);
         defer reader.deinit();
-        if (expected_n_atoms) |n_atoms| try ensureAtomCount(traj_path, n_atoms, reader.nAtoms());
+        if (expected_n_atoms) |n_atoms| try ensureAtomCount(io_handle, traj_path, n_atoms, reader.nAtoms());
 
         var n_frames: usize = 0;
         var first_time: ?f32 = null;
@@ -159,9 +160,9 @@ pub fn loadTrajectoryInfo(
         }
         return .{ .n_frames = n_frames, .first_time = first_time, .last_time = last_time };
     } else if (isNc(traj_path)) {
-        var reader = try io.nc.NcReader.open(allocator, traj_path);
+        var reader = try trajio.nc.NcReader.open(io_handle, allocator, traj_path);
         defer reader.deinit();
-        if (expected_n_atoms) |n_atoms| try ensureAtomCount(traj_path, n_atoms, reader.nAtoms());
+        if (expected_n_atoms) |n_atoms| try ensureAtomCount(io_handle, traj_path, n_atoms, reader.nAtoms());
 
         var n_frames: usize = 0;
         var first_time: ?f32 = null;
@@ -173,20 +174,20 @@ pub fn loadTrajectoryInfo(
         }
         return .{ .n_frames = n_frames, .first_time = first_time, .last_time = last_time };
     } else {
-        const data = try std.fs.cwd().readFileAlloc(allocator, traj_path, 512 * 1024 * 1024);
+        const data = try std.Io.Dir.cwd().readFileAlloc(io_handle, traj_path, allocator, .limited(512 * 1024 * 1024));
         defer allocator.free(data);
 
         var pr: types.ParseResult = if (isPdb(traj_path))
-            try io.pdb.parse(allocator, data)
+            try trajio.pdb.parse(allocator, data)
         else if (isCif(traj_path))
-            try io.mmcif.parse(allocator, data)
+            try trajio.mmcif.parse(allocator, data)
         else if (isGro(traj_path))
-            try io.gro.parse(allocator, data)
+            try trajio.gro.parse(allocator, data)
         else {
-            return unsupportedTrajectoryFormat(traj_path);
+            return unsupportedTrajectoryFormat(io_handle, traj_path);
         };
         defer pr.deinit();
-        if (expected_n_atoms) |n_atoms| try ensureAtomCount(traj_path, n_atoms, pr.frame.nAtoms());
+        if (expected_n_atoms) |n_atoms| try ensureAtomCount(io_handle, traj_path, n_atoms, pr.frame.nAtoms());
 
         return .{
             .n_frames = 1,
@@ -196,8 +197,8 @@ pub fn loadTrajectoryInfo(
     }
 }
 
-fn unsupportedTrajectoryFormat(_: []const u8) error{UnsupportedFormat} {
-    printStderr("error: unsupported trajectory/structure format (supported: .xtc, .trr, .dcd, .nc, .pdb, .cif, .mmcif, .gro)\n");
+fn unsupportedTrajectoryFormat(io_handle: std.Io, _: []const u8) error{UnsupportedFormat} {
+    printStderr(io_handle, "error: unsupported trajectory/structure format (supported: .xtc, .trr, .dcd, .nc, .pdb, .cif, .mmcif, .gro)\n");
     return error.UnsupportedFormat;
 }
 
@@ -205,21 +206,22 @@ fn unsupportedTrajectoryFormat(_: []const u8) error{UnsupportedFormat} {
 /// Returns allocated []Frame (caller frees each frame then the slice).
 /// An optional progress node is updated per frame loaded.
 pub fn loadAllFrames(
+    io_handle: std.Io,
     allocator: std.mem.Allocator,
     traj_path: []const u8,
     n_atoms: usize,
     progress_node: std.Progress.Node,
 ) ![]types.Frame {
-    var frames = std.ArrayList(types.Frame){};
+    var frames = std.ArrayList(types.Frame).empty;
     errdefer {
         for (frames.items) |*f| f.deinit();
         frames.deinit(allocator);
     }
 
     if (isXtc(traj_path)) {
-        var reader = try io.xtc.XtcReader.open(allocator, traj_path);
+        var reader = try trajio.xtc.XtcReader.open(io_handle, allocator, traj_path);
         defer reader.deinit();
-        try ensureAtomCount(traj_path, n_atoms, reader.nAtoms());
+        try ensureAtomCount(io_handle, traj_path, n_atoms, reader.nAtoms());
         while (try reader.next()) |frame_ptr| {
             var copy = try types.Frame.init(allocator, n_atoms);
             @memcpy(copy.x, frame_ptr.x);
@@ -232,9 +234,9 @@ pub fn loadAllFrames(
             progress_node.completeOne();
         }
     } else if (isDcd(traj_path)) {
-        var reader = try io.dcd.DcdReader.open(allocator, traj_path);
+        var reader = try trajio.dcd.DcdReader.open(io_handle, allocator, traj_path);
         defer reader.deinit();
-        try ensureAtomCount(traj_path, n_atoms, reader.nAtoms());
+        try ensureAtomCount(io_handle, traj_path, n_atoms, reader.nAtoms());
         while (try reader.next()) |frame_ptr| {
             var copy = try types.Frame.init(allocator, n_atoms);
             @memcpy(copy.x, frame_ptr.x);
@@ -247,9 +249,9 @@ pub fn loadAllFrames(
             progress_node.completeOne();
         }
     } else if (isTrr(traj_path)) {
-        var reader = try io.trr.TrrReader.open(allocator, traj_path);
+        var reader = try trajio.trr.TrrReader.open(io_handle, allocator, traj_path);
         defer reader.deinit();
-        try ensureAtomCount(traj_path, n_atoms, reader.nAtoms());
+        try ensureAtomCount(io_handle, traj_path, n_atoms, reader.nAtoms());
         while (try reader.next()) |frame_ptr| {
             var copy = try types.Frame.init(allocator, n_atoms);
             @memcpy(copy.x, frame_ptr.x);
@@ -262,9 +264,9 @@ pub fn loadAllFrames(
             progress_node.completeOne();
         }
     } else if (isNc(traj_path)) {
-        var reader = try io.nc.NcReader.open(allocator, traj_path);
+        var reader = try trajio.nc.NcReader.open(io_handle, allocator, traj_path);
         defer reader.deinit();
-        try ensureAtomCount(traj_path, n_atoms, reader.nAtoms());
+        try ensureAtomCount(io_handle, traj_path, n_atoms, reader.nAtoms());
         while (try reader.next()) |frame_ptr| {
             var copy = try types.Frame.init(allocator, n_atoms);
             @memcpy(copy.x, frame_ptr.x);
@@ -278,21 +280,21 @@ pub fn loadAllFrames(
         }
     } else {
         // Single-frame structure file — parse only for its coordinates.
-        const data = try std.fs.cwd().readFileAlloc(allocator, traj_path, 512 * 1024 * 1024);
+        const data = try std.Io.Dir.cwd().readFileAlloc(io_handle, traj_path, allocator, .limited(512 * 1024 * 1024));
         defer allocator.free(data);
         var pr: types.ParseResult = if (isPdb(traj_path))
-            try io.pdb.parse(allocator, data)
+            try trajio.pdb.parse(allocator, data)
         else if (isCif(traj_path))
-            try io.mmcif.parse(allocator, data)
+            try trajio.mmcif.parse(allocator, data)
         else if (isGro(traj_path))
-            try io.gro.parse(allocator, data)
+            try trajio.gro.parse(allocator, data)
         else {
-            return unsupportedTrajectoryFormat(traj_path);
+            return unsupportedTrajectoryFormat(io_handle, traj_path);
         };
         errdefer pr.frame.deinit();
         defer pr.topology.deinit();
 
-        try ensureAtomCount(traj_path, n_atoms, pr.frame.nAtoms());
+        try ensureAtomCount(io_handle, traj_path, n_atoms, pr.frame.nAtoms());
         try frames.append(allocator, pr.frame);
         progress_node.completeOne();
     }
@@ -303,6 +305,7 @@ pub fn loadAllFrames(
 /// Convenience wrapper: creates a "Loading frames" progress node, loads all
 /// frames, and ends the node automatically via defer.
 pub fn loadAllFramesWithProgress(
+    io_handle: std.Io,
     allocator: std.mem.Allocator,
     traj_path: []const u8,
     n_atoms: usize,
@@ -310,7 +313,7 @@ pub fn loadAllFramesWithProgress(
 ) ![]types.Frame {
     const load_node = progress_root.start("Loading frames", 0);
     defer load_node.end();
-    return loadAllFrames(allocator, traj_path, n_atoms, load_node);
+    return loadAllFrames(io_handle, allocator, traj_path, n_atoms, load_node);
 }
 
 test "loadTrajectoryInfo counts frames without materializing them" {

--- a/src/cli/parsers.zig
+++ b/src/cli/parsers.zig
@@ -11,7 +11,7 @@ const select = ztraj.select;
 // ============================================================================
 
 fn printStderr(msg: []const u8) void {
-    std.fs.File.stderr().writeAll(msg) catch {};
+    std.debug.print("{s}", .{msg});
 }
 
 fn requireNonEmptySelection(allocator: std.mem.Allocator, selection: []u32, sel_str: []const u8) ![]u32 {
@@ -55,13 +55,13 @@ pub fn resolveSelection(
 
 /// Parse "i-j,k-l" into [][2]u32.
 pub fn parsePairs(allocator: std.mem.Allocator, spec: []const u8) ![][2]u32 {
-    var list = std.ArrayList([2]u32){};
+    var list = std.ArrayList([2]u32).empty;
     errdefer list.deinit(allocator);
 
     var tok = std.mem.tokenizeScalar(u8, spec, ',');
     while (tok.next()) |token| {
         const t = std.mem.trim(u8, token, " \t");
-        const dash = std.mem.indexOfScalar(u8, t, '-') orelse return error.InvalidSpec;
+        const dash = std.mem.findScalar(u8, t, '-') orelse return error.InvalidSpec;
         const a = std.fmt.parseInt(u32, t[0..dash], 10) catch return error.InvalidSpec;
         const b = std.fmt.parseInt(u32, t[dash + 1 ..], 10) catch return error.InvalidSpec;
         try list.append(allocator, .{ a, b });
@@ -71,7 +71,7 @@ pub fn parsePairs(allocator: std.mem.Allocator, spec: []const u8) ![][2]u32 {
 
 /// Parse "i-j-k,l-m-n" into [][3]u32.
 pub fn parseTriplets(allocator: std.mem.Allocator, spec: []const u8) ![][3]u32 {
-    var list = std.ArrayList([3]u32){};
+    var list = std.ArrayList([3]u32).empty;
     errdefer list.deinit(allocator);
 
     var tok = std.mem.tokenizeScalar(u8, spec, ',');
@@ -93,7 +93,7 @@ pub fn parseTriplets(allocator: std.mem.Allocator, spec: []const u8) ![][3]u32 {
 
 /// Parse "i-j-k-l,m-n-o-p" into [][4]u32.
 pub fn parseQuartets(allocator: std.mem.Allocator, spec: []const u8) ![][4]u32 {
-    var list = std.ArrayList([4]u32){};
+    var list = std.ArrayList([4]u32).empty;
     errdefer list.deinit(allocator);
 
     var tok = std.mem.tokenizeScalar(u8, spec, ',');

--- a/src/cli/runners.zig
+++ b/src/cli/runners.zig
@@ -18,26 +18,25 @@ const parsers = @import("parsers.zig");
 // ============================================================================
 
 /// Write the buffered output to either a file or stdout.
-pub fn flushOutput(buf: []const u8, output_path: ?[]const u8) !void {
+pub fn flushOutput(io: std.Io, buf: []const u8, output_path: ?[]const u8) !void {
     if (output_path) |p| {
-        const file = try std.fs.cwd().createFile(p, .{});
-        defer file.close();
-        try file.writeAll(buf);
+        const file = try std.Io.Dir.cwd().createFile(io, p, .{});
+        defer file.close(io);
+        try file.writeStreamingAll(io, buf);
     } else {
-        const stdout = std.fs.File.stdout();
-        try stdout.writeAll(buf);
+        const stdout = std.Io.File.stdout();
+        try stdout.writeStreamingAll(io, buf);
     }
 }
 
 /// Write a single f64 array in the chosen format (one column).
 pub fn writeScalarSeriesBuf(
     allocator: std.mem.Allocator,
-    buf: *std.ArrayList(u8),
+    w: *std.Io.Writer,
     fmt: output.Format,
     key: []const u8,
     values: []const f64,
 ) !void {
-    const w = buf.writer(allocator);
     switch (fmt) {
         .json => {
             try w.writeAll("{\n  ");
@@ -65,17 +64,17 @@ pub fn writeScalarSeriesBuf(
 // Subcommand: rmsd
 // ============================================================================
 
-pub fn runRmsd(allocator: std.mem.Allocator, args: Args) !void {
-    const progress_root = std.Progress.start(.{ .root_name = "rmsd" });
+pub fn runRmsd(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
+    const progress_root = std.Progress.start(io, .{ .root_name = "rmsd" });
 
     const top_path = args.top_path orelse args.traj_path;
-    var parsed = try loader.loadTopology(allocator, top_path);
+    var parsed = try loader.loadTopology(io, allocator, top_path);
     defer parsed.deinit();
 
     const atom_indices = try parsers.resolveSelection(allocator, parsed.topology, args.select_str);
     defer if (atom_indices) |ai| allocator.free(ai);
 
-    const frames = try loader.loadAllFramesWithProgress(allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
+    const frames = try loader.loadAllFramesWithProgress(io, allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
     defer {
         for (frames) |*f| @constCast(f).deinit();
         allocator.free(frames);
@@ -114,27 +113,27 @@ pub fn runRmsd(allocator: std.mem.Allocator, args: Args) !void {
     analysis_node.end();
     progress_root.end();
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    try writeScalarSeriesBuf(allocator, &buf, args.format, "rmsd", rmsd_vals);
-    try flushOutput(buf.items, args.output_path);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    try writeScalarSeriesBuf(allocator, &aw.writer, args.format, "rmsd", rmsd_vals);
+    try flushOutput(io, aw.written(), args.output_path);
 }
 
 // ============================================================================
 // Subcommand: rmsf
 // ============================================================================
 
-pub fn runRmsf(allocator: std.mem.Allocator, args: Args) !void {
-    const progress_root = std.Progress.start(.{ .root_name = "rmsf" });
+pub fn runRmsf(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
+    const progress_root = std.Progress.start(io, .{ .root_name = "rmsf" });
 
     const top_path = args.top_path orelse args.traj_path;
-    var parsed = try loader.loadTopology(allocator, top_path);
+    var parsed = try loader.loadTopology(io, allocator, top_path);
     defer parsed.deinit();
 
     const atom_indices = try parsers.resolveSelection(allocator, parsed.topology, args.select_str);
     defer if (atom_indices) |ai| allocator.free(ai);
 
-    const frames = try loader.loadAllFramesWithProgress(allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
+    const frames = try loader.loadAllFramesWithProgress(io, allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
     defer {
         for (frames) |*f| @constCast(f).deinit();
         allocator.free(frames);
@@ -147,18 +146,18 @@ pub fn runRmsf(allocator: std.mem.Allocator, args: Args) !void {
     defer allocator.free(rmsf_vals);
     progress_root.end();
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    try writeScalarSeriesBuf(allocator, &buf, args.format, "rmsf", rmsf_vals);
-    try flushOutput(buf.items, args.output_path);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    try writeScalarSeriesBuf(allocator, &aw.writer, args.format, "rmsf", rmsf_vals);
+    try flushOutput(io, aw.written(), args.output_path);
 }
 
 // ============================================================================
 // Subcommand: distances
 // ============================================================================
 
-pub fn runDistances(allocator: std.mem.Allocator, args: Args) !void {
-    const progress_root = std.Progress.start(.{ .root_name = "distances" });
+pub fn runDistances(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
+    const progress_root = std.Progress.start(io, .{ .root_name = "distances" });
 
     const spec = args.pairs_spec orelse {
         std.debug.print("error: --pairs required for distances subcommand\n", .{});
@@ -168,12 +167,12 @@ pub fn runDistances(allocator: std.mem.Allocator, args: Args) !void {
     defer allocator.free(pairs);
 
     const top_path = args.top_path orelse args.traj_path;
-    var parsed = try loader.loadTopology(allocator, top_path);
+    var parsed = try loader.loadTopology(io, allocator, top_path);
     defer parsed.deinit();
 
     try parsers.validateIndices(2, pairs, @intCast(parsed.topology.atoms.len));
 
-    const frames = try loader.loadAllFramesWithProgress(allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
+    const frames = try loader.loadAllFramesWithProgress(io, allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
     defer {
         for (frames) |*f| @constCast(f).deinit();
         allocator.free(frames);
@@ -209,9 +208,9 @@ pub fn runDistances(allocator: std.mem.Allocator, args: Args) !void {
     }
     const const_headers: []const []const u8 = @ptrCast(headers);
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    const w = buf.writer(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
 
     switch (args.format) {
         .json => {
@@ -230,15 +229,15 @@ pub fn runDistances(allocator: std.mem.Allocator, args: Args) !void {
         .csv => try output.writeDelimited(w, const_headers, all_rows, ','),
         .tsv => try output.writeDelimited(w, const_headers, all_rows, '\t'),
     }
-    try flushOutput(buf.items, args.output_path);
+    try flushOutput(io, aw.written(), args.output_path);
 }
 
 // ============================================================================
 // Subcommand: angles
 // ============================================================================
 
-pub fn runAngles(allocator: std.mem.Allocator, args: Args) !void {
-    const progress_root = std.Progress.start(.{ .root_name = "angles" });
+pub fn runAngles(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
+    const progress_root = std.Progress.start(io, .{ .root_name = "angles" });
 
     const spec = args.triplets_spec orelse {
         std.debug.print("error: --triplets required for angles subcommand\n", .{});
@@ -248,12 +247,12 @@ pub fn runAngles(allocator: std.mem.Allocator, args: Args) !void {
     defer allocator.free(triplets);
 
     const top_path = args.top_path orelse args.traj_path;
-    var parsed = try loader.loadTopology(allocator, top_path);
+    var parsed = try loader.loadTopology(io, allocator, top_path);
     defer parsed.deinit();
 
     try parsers.validateIndices(3, triplets, @intCast(parsed.topology.atoms.len));
 
-    const frames = try loader.loadAllFramesWithProgress(allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
+    const frames = try loader.loadAllFramesWithProgress(io, allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
     defer {
         for (frames) |*f| @constCast(f).deinit();
         allocator.free(frames);
@@ -289,9 +288,9 @@ pub fn runAngles(allocator: std.mem.Allocator, args: Args) !void {
     }
     const const_headers: []const []const u8 = @ptrCast(headers);
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    const w = buf.writer(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
     switch (args.format) {
         .json => {
             try w.writeAll("{\n");
@@ -309,15 +308,15 @@ pub fn runAngles(allocator: std.mem.Allocator, args: Args) !void {
         .csv => try output.writeDelimited(w, const_headers, all_rows, ','),
         .tsv => try output.writeDelimited(w, const_headers, all_rows, '\t'),
     }
-    try flushOutput(buf.items, args.output_path);
+    try flushOutput(io, aw.written(), args.output_path);
 }
 
 // ============================================================================
 // Subcommand: dihedrals
 // ============================================================================
 
-pub fn runDihedrals(allocator: std.mem.Allocator, args: Args) !void {
-    const progress_root = std.Progress.start(.{ .root_name = "dihedrals" });
+pub fn runDihedrals(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
+    const progress_root = std.Progress.start(io, .{ .root_name = "dihedrals" });
 
     const spec = args.quartets_spec orelse {
         std.debug.print("error: --quartets required for dihedrals subcommand\n", .{});
@@ -327,12 +326,12 @@ pub fn runDihedrals(allocator: std.mem.Allocator, args: Args) !void {
     defer allocator.free(quartets);
 
     const top_path = args.top_path orelse args.traj_path;
-    var parsed = try loader.loadTopology(allocator, top_path);
+    var parsed = try loader.loadTopology(io, allocator, top_path);
     defer parsed.deinit();
 
     try parsers.validateIndices(4, quartets, @intCast(parsed.topology.atoms.len));
 
-    const frames = try loader.loadAllFramesWithProgress(allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
+    const frames = try loader.loadAllFramesWithProgress(io, allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
     defer {
         for (frames) |*f| @constCast(f).deinit();
         allocator.free(frames);
@@ -368,9 +367,9 @@ pub fn runDihedrals(allocator: std.mem.Allocator, args: Args) !void {
     }
     const const_headers: []const []const u8 = @ptrCast(headers);
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    const w = buf.writer(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
     switch (args.format) {
         .json => {
             try w.writeAll("{\n");
@@ -388,18 +387,18 @@ pub fn runDihedrals(allocator: std.mem.Allocator, args: Args) !void {
         .csv => try output.writeDelimited(w, const_headers, all_rows, ','),
         .tsv => try output.writeDelimited(w, const_headers, all_rows, '\t'),
     }
-    try flushOutput(buf.items, args.output_path);
+    try flushOutput(io, aw.written(), args.output_path);
 }
 
 // ============================================================================
 // Subcommand: rg
 // ============================================================================
 
-pub fn runRg(allocator: std.mem.Allocator, args: Args) !void {
-    const progress_root = std.Progress.start(.{ .root_name = "rg" });
+pub fn runRg(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
+    const progress_root = std.Progress.start(io, .{ .root_name = "rg" });
 
     const top_path = args.top_path orelse args.traj_path;
-    var parsed = try loader.loadTopology(allocator, top_path);
+    var parsed = try loader.loadTopology(io, allocator, top_path);
     defer parsed.deinit();
 
     const atom_indices = try parsers.resolveSelection(allocator, parsed.topology, args.select_str);
@@ -408,7 +407,7 @@ pub fn runRg(allocator: std.mem.Allocator, args: Args) !void {
     const masses = try parsed.topology.masses(allocator);
     defer allocator.free(masses);
 
-    const frames = try loader.loadAllFramesWithProgress(allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
+    const frames = try loader.loadAllFramesWithProgress(io, allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
     defer {
         for (frames) |*f| @constCast(f).deinit();
         allocator.free(frames);
@@ -424,21 +423,21 @@ pub fn runRg(allocator: std.mem.Allocator, args: Args) !void {
     analysis_node.end();
     progress_root.end();
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    try writeScalarSeriesBuf(allocator, &buf, args.format, "rg", rg_vals);
-    try flushOutput(buf.items, args.output_path);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    try writeScalarSeriesBuf(allocator, &aw.writer, args.format, "rg", rg_vals);
+    try flushOutput(io, aw.written(), args.output_path);
 }
 
 // ============================================================================
 // Subcommand: center
 // ============================================================================
 
-pub fn runCenter(allocator: std.mem.Allocator, args: Args) !void {
-    const progress_root = std.Progress.start(.{ .root_name = "center" });
+pub fn runCenter(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
+    const progress_root = std.Progress.start(io, .{ .root_name = "center" });
 
     const top_path = args.top_path orelse args.traj_path;
-    var parsed = try loader.loadTopology(allocator, top_path);
+    var parsed = try loader.loadTopology(io, allocator, top_path);
     defer parsed.deinit();
 
     const atom_indices = try parsers.resolveSelection(allocator, parsed.topology, args.select_str);
@@ -447,7 +446,7 @@ pub fn runCenter(allocator: std.mem.Allocator, args: Args) !void {
     const masses = try parsed.topology.masses(allocator);
     defer allocator.free(masses);
 
-    const frames = try loader.loadAllFramesWithProgress(allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
+    const frames = try loader.loadAllFramesWithProgress(io, allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
     defer {
         for (frames) |*f| @constCast(f).deinit();
         allocator.free(frames);
@@ -472,9 +471,9 @@ pub fn runCenter(allocator: std.mem.Allocator, args: Args) !void {
     progress_root.end();
 
     const headers = [_][]const u8{ "cx", "cy", "cz" };
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    const w = buf.writer(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
     switch (args.format) {
         .json => {
             const cx_vals = try allocator.alloc(f64, frames.len);
@@ -496,18 +495,18 @@ pub fn runCenter(allocator: std.mem.Allocator, args: Args) !void {
         .csv => try output.writeDelimited(w, &headers, all_rows, ','),
         .tsv => try output.writeDelimited(w, &headers, all_rows, '\t'),
     }
-    try flushOutput(buf.items, args.output_path);
+    try flushOutput(io, aw.written(), args.output_path);
 }
 
 // ============================================================================
 // Subcommand: inertia
 // ============================================================================
 
-pub fn runInertia(allocator: std.mem.Allocator, args: Args) !void {
-    const progress_root = std.Progress.start(.{ .root_name = "inertia" });
+pub fn runInertia(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
+    const progress_root = std.Progress.start(io, .{ .root_name = "inertia" });
 
     const top_path = args.top_path orelse args.traj_path;
-    var parsed = try loader.loadTopology(allocator, top_path);
+    var parsed = try loader.loadTopology(io, allocator, top_path);
     defer parsed.deinit();
 
     const atom_indices = try parsers.resolveSelection(allocator, parsed.topology, args.select_str);
@@ -516,7 +515,7 @@ pub fn runInertia(allocator: std.mem.Allocator, args: Args) !void {
     const masses = try parsed.topology.masses(allocator);
     defer allocator.free(masses);
 
-    const frames = try loader.loadAllFramesWithProgress(allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
+    const frames = try loader.loadAllFramesWithProgress(io, allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
     defer {
         for (frames) |*f| @constCast(f).deinit();
         allocator.free(frames);
@@ -542,9 +541,9 @@ pub fn runInertia(allocator: std.mem.Allocator, args: Args) !void {
     progress_root.end();
 
     const headers = [_][]const u8{ "I1", "I2", "I3" };
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    const w = buf.writer(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
     switch (args.format) {
         .json => {
             const mom1 = try allocator.alloc(f64, frames.len);
@@ -566,21 +565,21 @@ pub fn runInertia(allocator: std.mem.Allocator, args: Args) !void {
         .csv => try output.writeDelimited(w, &headers, all_rows, ','),
         .tsv => try output.writeDelimited(w, &headers, all_rows, '\t'),
     }
-    try flushOutput(buf.items, args.output_path);
+    try flushOutput(io, aw.written(), args.output_path);
 }
 
 // ============================================================================
 // Subcommand: hbonds
 // ============================================================================
 
-pub fn runHbonds(allocator: std.mem.Allocator, args: Args) !void {
-    const progress_root = std.Progress.start(.{ .root_name = "hbonds" });
+pub fn runHbonds(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
+    const progress_root = std.Progress.start(io, .{ .root_name = "hbonds" });
 
     const top_path = args.top_path orelse args.traj_path;
-    var parsed = try loader.loadTopology(allocator, top_path);
+    var parsed = try loader.loadTopology(io, allocator, top_path);
     defer parsed.deinit();
 
-    const frames = try loader.loadAllFramesWithProgress(allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
+    const frames = try loader.loadAllFramesWithProgress(io, allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
     defer {
         for (frames) |*f| @constCast(f).deinit();
         allocator.free(frames);
@@ -593,9 +592,9 @@ pub fn runHbonds(allocator: std.mem.Allocator, args: Args) !void {
 
     const n_threads = if (args.n_threads == 0) (std.Thread.getCpuCount() catch 1) else args.n_threads;
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    const w = buf.writer(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
 
     const analysis_node = progress_root.start("Detecting H-bonds", frames.len);
     switch (args.format) {
@@ -636,21 +635,21 @@ pub fn runHbonds(allocator: std.mem.Allocator, args: Args) !void {
     }
     analysis_node.end();
     progress_root.end();
-    try flushOutput(buf.items, args.output_path);
+    try flushOutput(io, aw.written(), args.output_path);
 }
 
 // ============================================================================
 // Subcommand: contacts
 // ============================================================================
 
-pub fn runContacts(allocator: std.mem.Allocator, args: Args) !void {
-    const progress_root = std.Progress.start(.{ .root_name = "contacts" });
+pub fn runContacts(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
+    const progress_root = std.Progress.start(io, .{ .root_name = "contacts" });
 
     const top_path = args.top_path orelse args.traj_path;
-    var parsed = try loader.loadTopology(allocator, top_path);
+    var parsed = try loader.loadTopology(io, allocator, top_path);
     defer parsed.deinit();
 
-    const frames = try loader.loadAllFramesWithProgress(allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
+    const frames = try loader.loadAllFramesWithProgress(io, allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
     defer {
         for (frames) |*f| @constCast(f).deinit();
         allocator.free(frames);
@@ -667,9 +666,9 @@ pub fn runContacts(allocator: std.mem.Allocator, args: Args) !void {
         std.process.exit(1);
     };
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    const w = buf.writer(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
 
     const analysis_node = progress_root.start("Computing contacts", frames.len);
     switch (args.format) {
@@ -725,15 +724,15 @@ pub fn runContacts(allocator: std.mem.Allocator, args: Args) !void {
     }
     analysis_node.end();
     progress_root.end();
-    try flushOutput(buf.items, args.output_path);
+    try flushOutput(io, aw.written(), args.output_path);
 }
 
 // ============================================================================
 // Subcommand: rdf
 // ============================================================================
 
-pub fn runRdf(allocator: std.mem.Allocator, args: Args) !void {
-    const progress_root = std.Progress.start(.{ .root_name = "rdf" });
+pub fn runRdf(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
+    const progress_root = std.Progress.start(io, .{ .root_name = "rdf" });
 
     if (args.sel1 == null or args.sel2 == null) {
         std.debug.print("error: --sel1 and --sel2 required for rdf subcommand\n", .{});
@@ -741,7 +740,7 @@ pub fn runRdf(allocator: std.mem.Allocator, args: Args) !void {
     }
 
     const top_path = args.top_path orelse args.traj_path;
-    var parsed = try loader.loadTopology(allocator, top_path);
+    var parsed = try loader.loadTopology(io, allocator, top_path);
     defer parsed.deinit();
 
     const idx1 = try parsers.resolveSelection(allocator, parsed.topology, args.sel1);
@@ -749,7 +748,7 @@ pub fn runRdf(allocator: std.mem.Allocator, args: Args) !void {
     const idx2 = try parsers.resolveSelection(allocator, parsed.topology, args.sel2);
     defer if (idx2) |ai| allocator.free(ai);
 
-    const frames = try loader.loadAllFramesWithProgress(allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
+    const frames = try loader.loadAllFramesWithProgress(io, allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
     defer {
         for (frames) |*f| @constCast(f).deinit();
         allocator.free(frames);
@@ -878,9 +877,9 @@ pub fn runRdf(allocator: std.mem.Allocator, args: Args) !void {
         std.process.exit(1);
     };
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    const w = buf.writer(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
 
     const headers = [_][]const u8{ "r", "g_r" };
     var all_rows = try allocator.alloc([]const f64, r_vals.len);
@@ -903,24 +902,24 @@ pub fn runRdf(allocator: std.mem.Allocator, args: Args) !void {
         .csv => try output.writeDelimited(w, &headers, all_rows, ','),
         .tsv => try output.writeDelimited(w, &headers, all_rows, '\t'),
     }
-    try flushOutput(buf.items, args.output_path);
+    try flushOutput(io, aw.written(), args.output_path);
 }
 
 // ============================================================================
 // Subcommand: sasa
 // ============================================================================
 
-pub fn runSasa(allocator: std.mem.Allocator, args: Args) !void {
-    const progress_root = std.Progress.start(.{ .root_name = "sasa" });
+pub fn runSasa(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
+    const progress_root = std.Progress.start(io, .{ .root_name = "sasa" });
 
     const top_path = args.top_path orelse args.traj_path;
-    var parsed = try loader.loadTopology(allocator, top_path);
+    var parsed = try loader.loadTopology(io, allocator, top_path);
     defer parsed.deinit();
 
     const atom_indices = try parsers.resolveSelection(allocator, parsed.topology, args.select_str);
     defer if (atom_indices) |ai| allocator.free(ai);
 
-    const frames = try loader.loadAllFramesWithProgress(allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
+    const frames = try loader.loadAllFramesWithProgress(io, allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
     defer {
         for (frames) |*f| @constCast(f).deinit();
         allocator.free(frames);
@@ -948,29 +947,29 @@ pub fn runSasa(allocator: std.mem.Allocator, args: Args) !void {
     analysis_node.end();
     progress_root.end();
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    try writeScalarSeriesBuf(allocator, &buf, args.format, "sasa", sasa_vals);
-    try flushOutput(buf.items, args.output_path);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    try writeScalarSeriesBuf(allocator, &aw.writer, args.format, "sasa", sasa_vals);
+    try flushOutput(io, aw.written(), args.output_path);
 }
 
 // ============================================================================
 // Subcommand: all (combined analysis)
 // ============================================================================
 
-pub fn runAll(allocator: std.mem.Allocator, args: Args) !void {
-    const progress_root = std.Progress.start(.{ .root_name = "all" });
+pub fn runAll(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
+    const progress_root = std.Progress.start(io, .{ .root_name = "all" });
 
     // The all command only supports JSON output (multi-metric data
     // doesn't map to flat CSV/TSV)
     if (args.format != .json) {
-        const stderr = std.fs.File.stderr();
-        try stderr.writeAll("error: 'all' command only supports JSON output (--format json)\n");
+        const stderr = std.Io.File.stderr();
+        try stderr.writeStreamingAll(io, "error: 'all' command only supports JSON output (--format json)\n");
         return error.UnsupportedFormat;
     }
 
     const top_path = args.top_path orelse args.traj_path;
-    var parsed = try loader.loadTopology(allocator, top_path);
+    var parsed = try loader.loadTopology(io, allocator, top_path);
     defer parsed.deinit();
 
     const atom_indices = try parsers.resolveSelection(allocator, parsed.topology, args.select_str);
@@ -979,7 +978,7 @@ pub fn runAll(allocator: std.mem.Allocator, args: Args) !void {
     const masses = try parsed.topology.masses(allocator);
     defer allocator.free(masses);
 
-    const frames = try loader.loadAllFramesWithProgress(allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
+    const frames = try loader.loadAllFramesWithProgress(io, allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
     defer {
         for (frames) |*f| @constCast(f).deinit();
         allocator.free(frames);
@@ -1071,9 +1070,9 @@ pub fn runAll(allocator: std.mem.Allocator, args: Args) !void {
     progress_root.end();
 
     // Write JSON output
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    const w = buf.writer(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
 
     const n_atoms = if (atom_indices) |ai| ai.len else parsed.topology.atoms.len;
 
@@ -1101,21 +1100,21 @@ pub fn runAll(allocator: std.mem.Allocator, args: Args) !void {
     }
     try w.writeAll("]\n}\n");
 
-    try flushOutput(buf.items, args.output_path);
+    try flushOutput(io, aw.written(), args.output_path);
 }
 
 // ============================================================================
 // Subcommand: dssp
 // ============================================================================
 
-pub fn runDssp(allocator: std.mem.Allocator, args: Args) !void {
-    const progress_root = std.Progress.start(.{ .root_name = "dssp" });
+pub fn runDssp(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
+    const progress_root = std.Progress.start(io, .{ .root_name = "dssp" });
 
     const top_path = args.top_path orelse args.traj_path;
-    var parsed = try loader.loadTopology(allocator, top_path);
+    var parsed = try loader.loadTopology(io, allocator, top_path);
     defer parsed.deinit();
 
-    const frames = try loader.loadAllFramesWithProgress(allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
+    const frames = try loader.loadAllFramesWithProgress(io, allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
     defer {
         for (frames) |*f| @constCast(f).deinit();
         allocator.free(frames);
@@ -1126,9 +1125,9 @@ pub fn runDssp(allocator: std.mem.Allocator, args: Args) !void {
     const n_threads = if (args.n_threads == 0) (std.Thread.getCpuCount() catch 1) else args.n_threads;
     const config = dssp_mod.DsspConfigT{ .n_threads = n_threads };
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    const w = buf.writer(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
 
     if (frames.len == 1) {
         // Single frame: output per-residue SS
@@ -1205,7 +1204,7 @@ pub fn runDssp(allocator: std.mem.Allocator, args: Args) !void {
         analysis_node.end();
     }
     progress_root.end();
-    try flushOutput(buf.items, args.output_path);
+    try flushOutput(io, aw.written(), args.output_path);
 }
 
 // ============================================================================
@@ -1215,27 +1214,28 @@ pub fn runDssp(allocator: std.mem.Allocator, args: Args) !void {
 const prot_dih = geometry.protein_dihedrals;
 
 fn runProteinDihedral(
+    io: std.Io,
     allocator: std.mem.Allocator,
     args: Args,
     comptime key: []const u8,
     computeFn: anytype,
 ) !void {
-    const progress_root = std.Progress.start(.{ .root_name = key });
+    const progress_root = std.Progress.start(io, .{ .root_name = key });
 
     const top_path = args.top_path orelse args.traj_path;
-    var parsed = try loader.loadTopology(allocator, top_path);
+    var parsed = try loader.loadTopology(io, allocator, top_path);
     defer parsed.deinit();
 
-    const frames = try loader.loadAllFramesWithProgress(allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
+    const frames = try loader.loadAllFramesWithProgress(io, allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
     defer {
         for (frames) |*f| @constCast(f).deinit();
         allocator.free(frames);
     }
     if (frames.len == 0) return error.NoFrames;
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    const w = buf.writer(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
 
     // Compute for each frame
     const analysis_node = progress_root.start("Computing " ++ key, frames.len);
@@ -1287,39 +1287,39 @@ fn runProteinDihedral(
             }
         },
     }
-    try flushOutput(buf.items, args.output_path);
+    try flushOutput(io, aw.written(), args.output_path);
 }
 
-pub fn runPhi(allocator: std.mem.Allocator, args: Args) !void {
-    return runProteinDihedral(allocator, args, "phi", prot_dih.computePhi);
+pub fn runPhi(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
+    return runProteinDihedral(io, allocator, args, "phi", prot_dih.computePhi);
 }
 
-pub fn runPsi(allocator: std.mem.Allocator, args: Args) !void {
-    return runProteinDihedral(allocator, args, "psi", prot_dih.computePsi);
+pub fn runPsi(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
+    return runProteinDihedral(io, allocator, args, "psi", prot_dih.computePsi);
 }
 
-pub fn runOmega(allocator: std.mem.Allocator, args: Args) !void {
-    return runProteinDihedral(allocator, args, "omega", prot_dih.computeOmega);
+pub fn runOmega(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
+    return runProteinDihedral(io, allocator, args, "omega", prot_dih.computeOmega);
 }
 
-pub fn runChi(allocator: std.mem.Allocator, args: Args) !void {
-    const progress_root = std.Progress.start(.{ .root_name = "chi" });
+pub fn runChi(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
+    const progress_root = std.Progress.start(io, .{ .root_name = "chi" });
 
     // chi level could be a CLI arg, default to 1 for now
     const top_path = args.top_path orelse args.traj_path;
-    var parsed = try loader.loadTopology(allocator, top_path);
+    var parsed = try loader.loadTopology(io, allocator, top_path);
     defer parsed.deinit();
 
-    const frames = try loader.loadAllFramesWithProgress(allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
+    const frames = try loader.loadAllFramesWithProgress(io, allocator, args.traj_path, parsed.topology.atoms.len, progress_root);
     defer {
         for (frames) |*f| @constCast(f).deinit();
         allocator.free(frames);
     }
     if (frames.len == 0) return error.NoFrames;
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    const w = buf.writer(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
 
     // Output chi1-chi4 for each frame
     const analysis_node = progress_root.start("Computing chi", frames.len);
@@ -1378,24 +1378,24 @@ pub fn runChi(allocator: std.mem.Allocator, args: Args) !void {
             }
         },
     }
-    try flushOutput(buf.items, args.output_path);
+    try flushOutput(io, aw.written(), args.output_path);
 }
 
 // ============================================================================
 // Subcommand: summary
 // ============================================================================
 
-pub fn runSummary(allocator: std.mem.Allocator, args: Args) !void {
+pub fn runSummary(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
     const top_path = args.top_path orelse args.traj_path;
-    var parsed = try loader.loadTopology(allocator, top_path);
+    var parsed = try loader.loadTopology(io, allocator, top_path);
     defer parsed.deinit();
 
     const topo = &parsed.topology;
     const frame = &parsed.frame;
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    const w = buf.writer(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
 
     // -- File + basic counts ------------------------------------------------
     try w.print("File:     {s}\n", .{top_path});
@@ -1484,7 +1484,7 @@ pub fn runSummary(allocator: std.mem.Allocator, args: Args) !void {
     // -- Trajectory info (if separate trajectory file) ----------------------
     const has_traj = args.top_path != null;
     if (has_traj) {
-        const traj_info = try loader.loadTrajectoryInfo(allocator, args.traj_path, topo.atoms.len);
+        const traj_info = try loader.loadTrajectoryInfo(io, allocator, args.traj_path, topo.atoms.len);
         try w.print("\nTrajectory: {s}\n", .{args.traj_path});
         try w.print("Frames:     {d}\n", .{traj_info.n_frames});
         if (traj_info.first_time != null and traj_info.last_time != null) {
@@ -1496,14 +1496,14 @@ pub fn runSummary(allocator: std.mem.Allocator, args: Args) !void {
         }
     }
 
-    try flushOutput(buf.items, args.output_path);
+    try flushOutput(io, aw.written(), args.output_path);
 }
 
 // ============================================================================
 // Subcommand: convert
 // ============================================================================
 
-pub fn runConvert(allocator: std.mem.Allocator, args: Args) !void {
+pub fn runConvert(io: std.Io, allocator: std.mem.Allocator, args: Args) !void {
     const output_path = args.output_path orelse {
         std.debug.print("error: convert requires --output <file>\n", .{});
         std.process.exit(1);
@@ -1517,12 +1517,12 @@ pub fn runConvert(allocator: std.mem.Allocator, args: Args) !void {
     if (is_traj_output or is_traj_input) {
         // Need topology for atom count
         const top_path = args.top_path orelse args.traj_path;
-        var parsed = try loader.loadTopology(allocator, top_path);
+        var parsed = try loader.loadTopology(io, allocator, top_path);
         defer parsed.deinit();
         const n_atoms = parsed.topology.atoms.len;
 
         // Load all frames from input
-        const frames = try loader.loadAllFrames(allocator, args.traj_path, n_atoms, std.Progress.Node.none);
+        const frames = try loader.loadAllFrames(io, allocator, args.traj_path, n_atoms, std.Progress.Node.none);
         defer {
             for (frames) |*f| @constCast(f).deinit();
             allocator.free(frames);
@@ -1534,36 +1534,36 @@ pub fn runConvert(allocator: std.mem.Allocator, args: Args) !void {
         }
 
         if (loader.isXtc(output_path)) {
-            var writer = try ztraj.io.xtc.XtcWriter.open(allocator, output_path, n_atoms);
+            var writer = try ztraj.io.xtc.XtcWriter.open(io, allocator, output_path, n_atoms);
             defer writer.deinit();
             for (frames) |frame| try writer.writeFrame(frame);
             try writer.close();
         } else if (loader.isTrr(output_path)) {
-            var writer = try ztraj.io.trr.TrrWriter.open(allocator, output_path, n_atoms);
+            var writer = try ztraj.io.trr.TrrWriter.open(io, allocator, output_path, n_atoms);
             defer writer.deinit();
             for (frames) |frame| try writer.writeFrame(frame);
             try writer.close();
         } else if (loader.isNc(output_path)) {
             const has_cell = frames[0].box_vectors != null;
-            var writer = try ztraj.io.nc.NcWriter.open(allocator, output_path, @intCast(n_atoms), has_cell);
+            var writer = try ztraj.io.nc.NcWriter.open(io, allocator, output_path, @intCast(n_atoms), has_cell);
             defer writer.deinit();
             for (frames) |frame| try writer.writeFrame(frame);
             try writer.close();
         } else if (loader.isPdb(output_path)) {
             // Trajectory → single-structure: write first frame only
-            var buf = std.ArrayList(u8){};
-            defer buf.deinit(allocator);
+            var aw: std.Io.Writer.Allocating = .init(allocator);
+            defer aw.deinit();
             if (frames.len > 0) {
-                try ztraj.io.pdb.write(buf.writer(allocator), parsed.topology, frames[0]);
+                try ztraj.io.pdb.write(&aw.writer, parsed.topology, frames[0]);
             }
-            try flushOutput(buf.items, output_path);
+            try flushOutput(io, aw.written(), output_path);
         } else if (loader.isGro(output_path)) {
-            var buf = std.ArrayList(u8){};
-            defer buf.deinit(allocator);
+            var aw: std.Io.Writer.Allocating = .init(allocator);
+            defer aw.deinit();
             if (frames.len > 0) {
-                try ztraj.io.gro.write(buf.writer(allocator), parsed.topology, frames[0]);
+                try ztraj.io.gro.write(&aw.writer, parsed.topology, frames[0]);
             }
-            try flushOutput(buf.items, output_path);
+            try flushOutput(io, aw.written(), output_path);
         } else {
             std.debug.print(
                 "error: unsupported output format for '{s}' (supported: .pdb, .gro, .xtc, .trr, .nc)\n",
@@ -1577,12 +1577,12 @@ pub fn runConvert(allocator: std.mem.Allocator, args: Args) !void {
         });
     } else {
         // Structure-only conversion (PDB/GRO/mmCIF → PDB/GRO)
-        var parsed = try loader.loadTopology(allocator, args.traj_path);
+        var parsed = try loader.loadTopology(io, allocator, args.traj_path);
         defer parsed.deinit();
 
-        var buf = std.ArrayList(u8){};
-        defer buf.deinit(allocator);
-        const w = buf.writer(allocator);
+        var aw: std.Io.Writer.Allocating = .init(allocator);
+        defer aw.deinit();
+        const w = &aw.writer;
 
         if (loader.isPdb(output_path)) {
             try ztraj.io.pdb.write(w, parsed.topology, parsed.frame);
@@ -1596,7 +1596,7 @@ pub fn runConvert(allocator: std.mem.Allocator, args: Args) !void {
             std.process.exit(1);
         }
 
-        try flushOutput(buf.items, output_path);
+        try flushOutput(io, aw.written(), output_path);
 
         std.debug.print("Converted {s} -> {s} ({d} atoms, {d} residues)\n", .{
             args.traj_path, output_path, parsed.topology.atoms.len, parsed.topology.residues.len,

--- a/src/io/cif_tokenizer.zig
+++ b/src/io/cif_tokenizer.zig
@@ -462,10 +462,14 @@ test "quoted string with embedded quote char" {
 }
 
 test "fuzz tokenizer" {
+    // 0.16 reworked the fuzz API: testOne now receives a `*std.testing.Smith`
+    // instead of a `[]const u8`. Pull bytes from Smith into a stack buffer
+    // and tokenize that.
     try std.testing.fuzz({}, struct {
-        fn testOne(_: void, input: []const u8) !void {
-            var tok = Tokenizer.init(input);
-            // Consume all tokens until EOF
+        fn testOne(_: void, smith: *std.testing.Smith) !void {
+            var buf: [4096]u8 = undefined;
+            const len = smith.sliceWithHash(&buf, 0);
+            var tok = Tokenizer.init(buf[0..len]);
             while (true) {
                 const token = tok.next();
                 if (token == .eof) break;

--- a/src/io/dcd.zig
+++ b/src/io/dcd.zig
@@ -54,7 +54,10 @@ const DcdHeader = struct {
 /// The reader reuses a single Frame buffer. The returned pointer is valid
 /// until the next call to next() or deinit().
 pub const DcdReader = struct {
-    file: std.fs.File,
+    io: std.Io,
+    file: std.Io.File,
+    reader: std.Io.File.Reader,
+    read_buffer: []u8,
     header: DcdHeader,
     /// Reused coordinate buffer (temporary, interleaved AOS) for reading.
     coord_buf: []f32,
@@ -66,14 +69,19 @@ pub const DcdReader = struct {
     const Self = @This();
 
     /// Open a DCD file for reading. Reads the header and allocates buffers.
-    pub fn open(allocator: std.mem.Allocator, path: []const u8) !Self {
-        const file = std.fs.cwd().openFile(path, .{}) catch |err| {
+    pub fn open(io: std.Io, allocator: std.mem.Allocator, path: []const u8) !Self {
+        const file = std.Io.Dir.cwd().openFile(io, path, .{}) catch |err| {
             return switch (err) {
                 error.FileNotFound => DcdError.FileNotFound,
                 else => DcdError.ReadError,
             };
         };
-        errdefer file.close();
+        errdefer file.close(io);
+
+        const read_buffer = allocator.alloc(u8, 64 * 1024) catch return DcdError.OutOfMemory;
+        errdefer allocator.free(read_buffer);
+
+        var reader = file.reader(io, read_buffer);
 
         // Bootstrap reader to parse header (we need endianness first).
         var hdr = DcdHeader{
@@ -86,7 +94,7 @@ pub const DcdReader = struct {
             .reverse_endian = false,
         };
 
-        try readHeader(file, &hdr);
+        try readHeader(&reader, &hdr);
 
         const n_atoms: usize = @intCast(hdr.natoms);
 
@@ -97,7 +105,10 @@ pub const DcdReader = struct {
         errdefer frame.deinit();
 
         return Self{
+            .io = io,
             .file = file,
+            .reader = reader,
+            .read_buffer = read_buffer,
             .header = hdr,
             .coord_buf = coord_buf,
             .frame = frame,
@@ -110,7 +121,8 @@ pub const DcdReader = struct {
     pub fn deinit(self: *Self) void {
         self.frame.deinit();
         self.allocator.free(self.coord_buf);
-        self.file.close();
+        self.allocator.free(self.read_buffer);
+        self.file.close(self.io);
     }
 
     /// Number of atoms in the trajectory.
@@ -176,7 +188,7 @@ pub const DcdReader = struct {
                 };
             } else {
                 // Unknown block — skip it.
-                self.file.seekBy(@intCast(uc_marker)) catch return DcdError.ReadError;
+                self.reader.seekBy(@intCast(uc_marker)) catch return DcdError.ReadError;
             }
             _ = try self.readRawInt32();
         }
@@ -191,7 +203,7 @@ pub const DcdReader = struct {
             (self.header.charmm & DCD_HAS_4DIMS) != 0)
         {
             const dim4_marker = try self.readInt32();
-            self.file.seekBy(@intCast(dim4_marker)) catch return DcdError.ReadError;
+            self.reader.seekBy(@intCast(dim4_marker)) catch return DcdError.ReadError;
             _ = try self.readRawInt32();
         }
 
@@ -218,8 +230,10 @@ pub const DcdReader = struct {
             // Read and byte-swap each float individually.
             var raw: [4]u8 = undefined;
             for (0..natoms) |i| {
-                const n = self.file.readAll(&raw) catch return DcdError.ReadError;
-                if (n < 4) return DcdError.EndOfFile;
+                self.reader.interface.readSliceAll(&raw) catch |err| switch (err) {
+                    error.EndOfStream => return DcdError.EndOfFile,
+                    else => return DcdError.ReadError,
+                };
                 const swapped = @byteSwap(std.mem.readInt(u32, &raw, .little));
                 dest[i] = @bitCast(swapped);
             }
@@ -228,8 +242,10 @@ pub const DcdReader = struct {
             const byte_count = natoms * 4;
             const tmp = self.coord_buf[0..natoms];
             const tmp_bytes: [*]u8 = @ptrCast(tmp.ptr);
-            const n = self.file.readAll(tmp_bytes[0..byte_count]) catch return DcdError.ReadError;
-            if (n < byte_count) return DcdError.EndOfFile;
+            self.reader.interface.readSliceAll(tmp_bytes[0..byte_count]) catch |err| switch (err) {
+                error.EndOfStream => return DcdError.EndOfFile,
+                else => return DcdError.ReadError,
+            };
             @memcpy(dest, tmp);
         }
 
@@ -245,16 +261,20 @@ pub const DcdReader = struct {
     /// Used for the very first int (before we know endianness).
     fn readRawInt32(self: *Self) !i32 {
         var buf: [4]u8 = undefined;
-        const n = self.file.readAll(&buf) catch return DcdError.ReadError;
-        if (n < 4) return DcdError.EndOfFile;
+        self.reader.interface.readSliceAll(&buf) catch |err| switch (err) {
+            error.EndOfStream => return DcdError.EndOfFile,
+            else => return DcdError.ReadError,
+        };
         return @bitCast(std.mem.readInt(u32, &buf, .little));
     }
 
     /// Read int32 with endian handling.
     fn readInt32(self: *Self) !i32 {
         var buf: [4]u8 = undefined;
-        const n = self.file.readAll(&buf) catch return DcdError.ReadError;
-        if (n < 4) return DcdError.EndOfFile;
+        self.reader.interface.readSliceAll(&buf) catch |err| switch (err) {
+            error.EndOfStream => return DcdError.EndOfFile,
+            else => return DcdError.ReadError,
+        };
         if (self.header.reverse_endian) {
             return @bitCast(std.mem.readInt(u32, &buf, .big));
         }
@@ -264,8 +284,10 @@ pub const DcdReader = struct {
     /// Read float64 with endian handling.
     fn readFloat64(self: *Self) !f64 {
         var buf: [8]u8 = undefined;
-        const n = self.file.readAll(&buf) catch return DcdError.ReadError;
-        if (n < 8) return DcdError.EndOfFile;
+        self.reader.interface.readSliceAll(&buf) catch |err| switch (err) {
+            error.EndOfStream => return DcdError.EndOfFile,
+            else => return DcdError.ReadError,
+        };
         if (self.header.reverse_endian) {
             return @bitCast(std.mem.readInt(u64, &buf, .big));
         }
@@ -274,16 +296,18 @@ pub const DcdReader = struct {
 };
 
 // ============================================================================
-// Header parser (free function, operates on std.fs.File)
+// Header parser (free function, operates on a std.Io.File.Reader)
 // ============================================================================
 
-fn readHeader(file: std.fs.File, hdr: *DcdHeader) !void {
-    // Helper closures — inline so we can use the file and hdr from the outer scope.
+fn readHeader(reader: *std.Io.File.Reader, hdr: *DcdHeader) !void {
+    // Helper closures — inline so we can use the reader and hdr from the outer scope.
     const readRawInt = struct {
-        fn call(f: std.fs.File) !i32 {
+        fn call(r: *std.Io.File.Reader) !i32 {
             var buf: [4]u8 = undefined;
-            const n = f.readAll(&buf) catch return DcdError.ReadError;
-            if (n < 4) return DcdError.EndOfFile;
+            r.interface.readSliceAll(&buf) catch |err| switch (err) {
+                error.EndOfStream => return DcdError.EndOfFile,
+                else => return DcdError.ReadError,
+            };
             return @bitCast(std.mem.readInt(u32, &buf, .little));
         }
     }.call;
@@ -310,7 +334,7 @@ fn readHeader(file: std.fs.File, hdr: *DcdHeader) !void {
     }.call;
 
     // 1. Read first int32 — should be 84.
-    var first_int = try readRawInt(file);
+    var first_int = try readRawInt(reader);
     if (first_int != 84) {
         first_int = @bitCast(@byteSwap(@as(u32, @bitCast(first_int))));
         if (first_int == 84) {
@@ -323,8 +347,10 @@ fn readHeader(file: std.fs.File, hdr: *DcdHeader) !void {
 
     // 2. Read 84-byte header block.
     var hdrbuf: [84]u8 = undefined;
-    const hdr_n = file.readAll(&hdrbuf) catch return DcdError.ReadError;
-    if (hdr_n < 84) return DcdError.BadFormat;
+    reader.interface.readSliceAll(&hdrbuf) catch |err| switch (err) {
+        error.EndOfStream => return DcdError.BadFormat,
+        else => return DcdError.ReadError,
+    };
 
     // Check "CORD" magic.
     if (hdrbuf[0] != 'C' or hdrbuf[1] != 'O' or hdrbuf[2] != 'R' or hdrbuf[3] != 'D') {
@@ -358,39 +384,41 @@ fn readHeader(file: std.fs.File, hdr: *DcdHeader) !void {
 
     // Trailing marker of block 1.
     const readIntSwap = struct {
-        fn call(f: std.fs.File, s: bool) !i32 {
+        fn call(r: *std.Io.File.Reader, s: bool) !i32 {
             var buf: [4]u8 = undefined;
-            const n = f.readAll(&buf) catch return DcdError.ReadError;
-            if (n < 4) return DcdError.EndOfFile;
+            r.interface.readSliceAll(&buf) catch |err| switch (err) {
+                error.EndOfStream => return DcdError.EndOfFile,
+                else => return DcdError.ReadError,
+            };
             if (s) return @bitCast(std.mem.readInt(u32, &buf, .big));
             return @bitCast(std.mem.readInt(u32, &buf, .little));
         }
     }.call;
 
-    const trail1 = try readIntSwap(file, swap);
+    const trail1 = try readIntSwap(reader, swap);
     if (trail1 != 84) return DcdError.BadFormat;
 
     // 3. Title block.
-    const title_block_size = try readIntSwap(file, swap);
+    const title_block_size = try readIntSwap(reader, swap);
     if (title_block_size < 4 or @mod(title_block_size - 4, 80) != 0) return DcdError.BadFormat;
 
-    const ntitle = try readIntSwap(file, swap);
+    const ntitle = try readIntSwap(reader, swap);
     if (ntitle < 0) return DcdError.BadFormat;
 
     const title_bytes: usize = @intCast(ntitle * 80);
     if (title_bytes > 0) {
-        file.seekBy(@intCast(title_bytes)) catch return DcdError.ReadError;
+        reader.seekBy(@intCast(title_bytes)) catch return DcdError.ReadError;
     }
-    _ = try readRawInt(file); // trailing marker
+    _ = try readRawInt(reader); // trailing marker
 
     // 4. Natoms block.
-    const natom_marker = try readIntSwap(file, swap);
+    const natom_marker = try readIntSwap(reader, swap);
     if (natom_marker != 4) return DcdError.BadFormat;
 
-    hdr.natoms = try readIntSwap(file, swap);
+    hdr.natoms = try readIntSwap(reader, swap);
     if (hdr.natoms <= 0) return DcdError.BadFormat;
 
-    const natom_trail = try readIntSwap(file, swap);
+    const natom_trail = try readIntSwap(reader, swap);
     if (natom_trail != 4) return DcdError.BadFormat;
 
     // Fixed atoms are unsupported.

--- a/src/io/dcd.zig
+++ b/src/io/dcd.zig
@@ -44,7 +44,7 @@ const DcdHeader = struct {
 ///
 /// Usage:
 ///
-///   var reader = try DcdReader.open(allocator, "trajectory.dcd");
+///   var reader = try DcdReader.open(io, allocator, "trajectory.dcd");
 ///   defer reader.deinit();
 ///
 ///   while (try reader.next()) |frame| {
@@ -429,22 +429,29 @@ fn readHeader(reader: *std.Io.File.Reader, hdr: *DcdHeader) !void {
 // Tests
 // ============================================================================
 
+fn testIo() std.Io {
+    const t = struct {
+        var threaded: std.Io.Threaded = .init_single_threaded;
+    };
+    return t.threaded.io();
+}
+
 test "DcdReader open returns FileNotFound for missing path" {
     const allocator = std.testing.allocator;
-    const result = DcdReader.open(allocator, "nonexistent.dcd");
+    const result = DcdReader.open(testIo(), allocator, "nonexistent.dcd");
     try std.testing.expectError(DcdError.FileNotFound, result);
 }
 
 test "DcdReader open returns FileNotFound for nonexistent path" {
     const allocator = std.testing.allocator;
-    const err = DcdReader.open(allocator, "/no/such/file/trajectory.dcd");
+    const err = DcdReader.open(testIo(), allocator, "/no/such/file/trajectory.dcd");
     try std.testing.expectError(DcdError.FileNotFound, err);
 }
 
 test "DcdReader reads existing DCD file" {
     const allocator = std.testing.allocator;
 
-    var reader = DcdReader.open(allocator, "test_data/1l2y.dcd") catch |err| {
+    var reader = DcdReader.open(testIo(), allocator, "test_data/1l2y.dcd") catch |err| {
         if (err == DcdError.FileNotFound) return; // Skip if test data not present.
         return err;
     };
@@ -471,7 +478,7 @@ test "DcdReader reads existing DCD file" {
 test "DcdReader reads all frames from DCD file" {
     const allocator = std.testing.allocator;
 
-    var reader = DcdReader.open(allocator, "test_data/1l2y.dcd") catch |err| {
+    var reader = DcdReader.open(testIo(), allocator, "test_data/1l2y.dcd") catch |err| {
         if (err == DcdError.FileNotFound) return;
         return err;
     };

--- a/src/io/gro.zig
+++ b/src/io/gro.zig
@@ -279,7 +279,7 @@ pub fn parse(allocator: std.mem.Allocator, data: []const u8) !types.ParseResult 
     // Line 1: Title
     // -------------------------------------------------------------------------
     const title_line = lines.next() orelse return ParseError.InvalidFormat;
-    const title = std.mem.trimRight(u8, title_line, "\r");
+    const title = std.mem.trimEnd(u8, title_line, "\r");
     const frame_time = parseTime(title);
 
     // -------------------------------------------------------------------------
@@ -296,7 +296,7 @@ pub fn parse(allocator: std.mem.Allocator, data: []const u8) !types.ParseResult 
     // -------------------------------------------------------------------------
     // Pass 1: collect raw atoms
     // -------------------------------------------------------------------------
-    var raw_atoms = std.ArrayListUnmanaged(RawAtom){};
+    var raw_atoms = std.ArrayList(RawAtom).empty;
     defer raw_atoms.deinit(allocator);
 
     try raw_atoms.ensureTotalCapacity(allocator, n_atoms_expected);
@@ -306,7 +306,7 @@ pub fn parse(allocator: std.mem.Allocator, data: []const u8) !types.ParseResult 
 
     var atom_count: u32 = 0;
     while (lines.next()) |line_raw| {
-        const line = std.mem.trimRight(u8, line_raw, "\r");
+        const line = std.mem.trimEnd(u8, line_raw, "\r");
 
         if (atom_count >= n_atoms_expected) {
             // This is the box vector line (or trailing content)
@@ -829,12 +829,12 @@ test "write GRO round-trip" {
     defer result.deinit();
 
     // Write to buffer
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
-    try write(buf.writer(allocator), result.topology, result.frame);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    try write(&aw.writer, result.topology, result.frame);
 
     // Parse the written output
-    var result2 = try parse(allocator, buf.items);
+    var result2 = try parse(allocator, aw.written());
     defer result2.deinit();
 
     // Compare

--- a/src/io/mmcif.zig
+++ b/src/io/mmcif.zig
@@ -243,7 +243,7 @@ pub fn parse(allocator: std.mem.Allocator, data: []const u8) !types.ParseResult 
     // ------------------------------------------------------------------
     // Phase 2: read rows and collect raw atoms
     // ------------------------------------------------------------------
-    var raw_atoms = std.ArrayListUnmanaged(RawAtom){};
+    var raw_atoms = std.ArrayList(RawAtom).empty;
     defer raw_atoms.deinit(allocator);
 
     var row = try allocator.alloc([]const u8, num_cols);

--- a/src/io/nc.zig
+++ b/src/io/nc.zig
@@ -77,7 +77,7 @@ const VarInfo = struct {
 ///
 /// Usage:
 ///
-///   var reader = try NcReader.open(allocator, "trajectory.nc");
+///   var reader = try NcReader.open(testIo(), allocator, "trajectory.nc");
 ///   defer reader.deinit();
 ///
 ///   while (try reader.next()) |frame| {
@@ -87,7 +87,10 @@ const VarInfo = struct {
 /// The reader reuses a single Frame buffer. The returned pointer is valid
 /// until the next call to next() or deinit().
 pub const NcReader = struct {
-    file: std.fs.File,
+    io: std.Io,
+    file: std.Io.File,
+    reader: std.Io.File.Reader,
+    read_buffer: []u8,
     allocator: std.mem.Allocator,
     frame: types.Frame,
     /// Per-frame coordinate data buffer (AOS: x0,y0,z0,x1,y1,z1,...)
@@ -106,18 +109,23 @@ pub const NcReader = struct {
     const Self = @This();
 
     /// Open an AMBER NetCDF trajectory for reading.
-    pub fn open(allocator: std.mem.Allocator, path: []const u8) !Self {
-        const file = std.fs.cwd().openFile(path, .{}) catch |err| {
+    pub fn open(io: std.Io, allocator: std.mem.Allocator, path: []const u8) !Self {
+        const file = std.Io.Dir.cwd().openFile(io, path, .{}) catch |err| {
             return switch (err) {
                 error.FileNotFound => NcError.FileNotFound,
                 else => NcError.ReadError,
             };
         };
-        errdefer file.close();
+        errdefer file.close(io);
+
+        const read_buffer = allocator.alloc(u8, 64 * 1024) catch return NcError.OutOfMemory;
+        errdefer allocator.free(read_buffer);
+
+        var reader = file.reader(io, read_buffer);
 
         // ---- Magic and version ----
         var magic: [4]u8 = undefined;
-        readExact(file, &magic) catch return NcError.ReadError;
+        readExact(&reader, &magic) catch return NcError.ReadError;
         if (magic[0] != 'C' or magic[1] != 'D' or magic[2] != 'F')
             return NcError.InvalidMagic;
         if (magic[3] != 1 and magic[3] != 2)
@@ -126,11 +134,11 @@ pub const NcReader = struct {
         const is_64bit = magic[3] == 2;
 
         // ---- Number of records (unlimited dimension length) ----
-        const numrecs = fileReadU32(file) catch return NcError.ReadError;
+        const numrecs = fileReadU32(&reader) catch return NcError.ReadError;
 
         // ---- Parse dimensions ----
         const DimInfo = struct { size: u32, is_unlimited: bool };
-        var dims = std.ArrayListUnmanaged(DimInfo){};
+        var dims = std.ArrayList(DimInfo).empty;
         defer dims.deinit(allocator);
 
         var n_atoms: u32 = 0;
@@ -138,14 +146,14 @@ pub const NcReader = struct {
         var spatial_size: u32 = 0;
 
         {
-            const tag = fileReadU32(file) catch return NcError.ReadError;
-            const n_dims = fileReadU32(file) catch return NcError.ReadError;
+            const tag = fileReadU32(&reader) catch return NcError.ReadError;
+            const n_dims = fileReadU32(&reader) catch return NcError.ReadError;
 
             if (tag == NC_DIMENSION and n_dims > 0) {
                 for (0..n_dims) |_| {
-                    const name = try readNcName(file, allocator);
+                    const name = try readNcName(&reader, allocator);
                     defer allocator.free(name);
-                    const dim_len = fileReadU32(file) catch return NcError.ReadError;
+                    const dim_len = fileReadU32(&reader) catch return NcError.ReadError;
 
                     const is_unlim = dim_len == 0;
                     const size = if (is_unlim) numrecs else dim_len;
@@ -173,15 +181,15 @@ pub const NcReader = struct {
         // ---- Parse global attributes ----
         var is_amber = false;
         {
-            const tag = fileReadU32(file) catch return NcError.ReadError;
-            const n_attrs = fileReadU32(file) catch return NcError.ReadError;
+            const tag = fileReadU32(&reader) catch return NcError.ReadError;
+            const n_attrs = fileReadU32(&reader) catch return NcError.ReadError;
 
             if (tag == NC_ATTRIBUTE and n_attrs > 0) {
                 for (0..n_attrs) |_| {
-                    const name = try readNcName(file, allocator);
+                    const name = try readNcName(&reader, allocator);
                     defer allocator.free(name);
-                    const attr_type = fileReadU32(file) catch return NcError.ReadError;
-                    const attr_nelems = fileReadU32(file) catch return NcError.ReadError;
+                    const attr_type = fileReadU32(&reader) catch return NcError.ReadError;
+                    const attr_nelems = fileReadU32(&reader) catch return NcError.ReadError;
 
                     const type_size = try ncTypeSize(attr_type);
                     const attr_bytes: u64 = @as(u64, attr_nelems) * type_size;
@@ -190,14 +198,14 @@ pub const NcReader = struct {
                     if (std.mem.eql(u8, name, "Conventions")) {
                         if (attr_type == NC_CHAR and attr_nelems <= 64) {
                             var buf: [64]u8 = undefined;
-                            readExact(file, buf[0..@intCast(padded)]) catch return NcError.ReadError;
+                            readExact(&reader, buf[0..@intCast(padded)]) catch return NcError.ReadError;
                             const val = std.mem.trim(u8, buf[0..attr_nelems], " \x00");
                             if (std.mem.eql(u8, val, "AMBER")) is_amber = true;
                             continue;
                         }
                     }
                     // Skip attribute data
-                    file.seekBy(@intCast(padded)) catch return NcError.ReadError;
+                    reader.seekBy(@intCast(padded)) catch return NcError.ReadError;
                 }
             } else if (tag == 0 and n_attrs == 0) {
                 // ABSENT
@@ -216,48 +224,48 @@ pub const NcReader = struct {
         var rec_size: u64 = 0;
 
         {
-            const tag = fileReadU32(file) catch return NcError.ReadError;
-            const n_vars = fileReadU32(file) catch return NcError.ReadError;
+            const tag = fileReadU32(&reader) catch return NcError.ReadError;
+            const n_vars = fileReadU32(&reader) catch return NcError.ReadError;
 
             if (tag == NC_VARIABLE and n_vars > 0) {
                 for (0..n_vars) |_| {
-                    const name = try readNcName(file, allocator);
+                    const name = try readNcName(&reader, allocator);
                     defer allocator.free(name);
 
                     // Number of dimensions
-                    const n_var_dims = fileReadU32(file) catch return NcError.ReadError;
+                    const n_var_dims = fileReadU32(&reader) catch return NcError.ReadError;
                     var is_record_var = false;
 
                     for (0..n_var_dims) |_| {
-                        const dim_id = fileReadU32(file) catch return NcError.ReadError;
+                        const dim_id = fileReadU32(&reader) catch return NcError.ReadError;
                         if (dim_id >= dims.items.len) return NcError.BadDimension;
                         if (dims.items[dim_id].is_unlimited) is_record_var = true;
                     }
 
                     // Skip variable attributes
-                    const va_tag = fileReadU32(file) catch return NcError.ReadError;
-                    const va_count = fileReadU32(file) catch return NcError.ReadError;
+                    const va_tag = fileReadU32(&reader) catch return NcError.ReadError;
+                    const va_count = fileReadU32(&reader) catch return NcError.ReadError;
                     if (va_tag == NC_ATTRIBUTE and va_count > 0) {
                         for (0..va_count) |_| {
-                            try skipNcName(file);
-                            const at = fileReadU32(file) catch return NcError.ReadError;
-                            const an = fileReadU32(file) catch return NcError.ReadError;
+                            try skipNcName(&reader);
+                            const at = fileReadU32(&reader) catch return NcError.ReadError;
+                            const an = fileReadU32(&reader) catch return NcError.ReadError;
                             const ts = try ncTypeSize(at);
                             const ab: u64 = @as(u64, an) * ts;
                             const ap: u64 = (ab + 3) & ~@as(u64, 3);
-                            file.seekBy(@intCast(ap)) catch return NcError.ReadError;
+                            reader.seekBy(@intCast(ap)) catch return NcError.ReadError;
                         }
                     }
 
-                    const nc_type = fileReadU32(file) catch return NcError.ReadError;
+                    const nc_type = fileReadU32(&reader) catch return NcError.ReadError;
                     // vsize: per-record size for record vars, total size for fixed vars
-                    const vsize = fileReadU32(file) catch return NcError.ReadError;
+                    const vsize = fileReadU32(&reader) catch return NcError.ReadError;
 
                     // begin: data offset (4 bytes for CDF-1, 8 bytes for CDF-2)
                     const offset: u64 = if (is_64bit)
-                        fileReadU64(file) catch return NcError.ReadError
+                        fileReadU64(&reader) catch return NcError.ReadError
                     else
-                        fileReadU32(file) catch return NcError.ReadError;
+                        fileReadU32(&reader) catch return NcError.ReadError;
 
                     const info = VarInfo{
                         .offset = offset,
@@ -291,7 +299,10 @@ pub const NcReader = struct {
         errdefer frame.deinit();
 
         return Self{
+            .io = io,
             .file = file,
+            .reader = reader,
+            .read_buffer = read_buffer,
             .allocator = allocator,
             .frame = frame,
             .coord_buf = coord_buf,
@@ -310,7 +321,8 @@ pub const NcReader = struct {
     pub fn deinit(self: *Self) void {
         self.frame.deinit();
         self.allocator.free(self.coord_buf);
-        self.file.close();
+        self.allocator.free(self.read_buffer);
+        self.file.close(self.io);
     }
 
     /// Number of atoms in the trajectory.
@@ -336,8 +348,8 @@ pub const NcReader = struct {
         // ---- Read coordinates ----
         {
             const offset = self.coords_var.offset + fi * self.rec_size;
-            self.file.seekTo(offset) catch return NcError.ReadError;
-            readExact(self.file, self.coord_buf) catch return NcError.ReadError;
+            self.reader.seekTo(offset) catch return NcError.ReadError;
+            readExact(&self.reader, self.coord_buf) catch return NcError.ReadError;
 
             // Convert AOS big-endian float32 → SOA native f32
             const n: usize = self.n_atoms;
@@ -352,9 +364,9 @@ pub const NcReader = struct {
         // ---- Read time (optional) ----
         if (self.time_var) |tv| {
             const offset = tv.offset + fi * self.rec_size;
-            self.file.seekTo(offset) catch return NcError.ReadError;
+            self.reader.seekTo(offset) catch return NcError.ReadError;
             var buf: [4]u8 = undefined;
-            readExact(self.file, &buf) catch return NcError.ReadError;
+            readExact(&self.reader, &buf) catch return NcError.ReadError;
             self.frame.time = readBEf32(&buf);
         } else {
             self.frame.time = 0.0;
@@ -364,14 +376,14 @@ pub const NcReader = struct {
         if (self.cell_lengths_var) |cl| {
             if (self.cell_angles_var) |ca| {
                 const cl_offset = cl.offset + fi * self.rec_size;
-                self.file.seekTo(cl_offset) catch return NcError.ReadError;
+                self.reader.seekTo(cl_offset) catch return NcError.ReadError;
                 var lbuf: [24]u8 = undefined; // 3 * f64
-                readExact(self.file, &lbuf) catch return NcError.ReadError;
+                readExact(&self.reader, &lbuf) catch return NcError.ReadError;
 
                 const ca_offset = ca.offset + fi * self.rec_size;
-                self.file.seekTo(ca_offset) catch return NcError.ReadError;
+                self.reader.seekTo(ca_offset) catch return NcError.ReadError;
                 var abuf: [24]u8 = undefined;
-                readExact(self.file, &abuf) catch return NcError.ReadError;
+                readExact(&self.reader, &abuf) catch return NcError.ReadError;
 
                 const a: f32 = @floatCast(readBEf64(lbuf[0..8]));
                 const b: f32 = @floatCast(readBEf64(lbuf[8..16]));
@@ -440,32 +452,31 @@ fn readBEf64(bytes: *const [8]u8) f64 {
     return @bitCast(std.mem.readInt(u64, bytes, .big));
 }
 
-/// Read exactly buf.len bytes from a file.
-fn readExact(file: std.fs.File, buf: []u8) !void {
-    const n = file.readAll(buf) catch return NcError.ReadError;
-    if (n != buf.len) return NcError.ReadError;
+/// Read exactly buf.len bytes from a file reader.
+fn readExact(reader: *std.Io.File.Reader, buf: []u8) !void {
+    reader.interface.readSliceAll(buf) catch return NcError.ReadError;
 }
 
-fn fileReadU32(file: std.fs.File) !u32 {
+fn fileReadU32(reader: *std.Io.File.Reader) !u32 {
     var buf: [4]u8 = undefined;
-    try readExact(file, &buf);
+    try readExact(reader, &buf);
     return std.mem.readInt(u32, &buf, .big);
 }
 
-fn fileReadU64(file: std.fs.File) !u64 {
+fn fileReadU64(reader: *std.Io.File.Reader) !u64 {
     var buf: [8]u8 = undefined;
-    try readExact(file, &buf);
+    try readExact(reader, &buf);
     return std.mem.readInt(u64, &buf, .big);
 }
 
 /// Read a NetCDF name: u32 length, then chars padded to 4-byte boundary.
-fn readNcName(file: std.fs.File, allocator: std.mem.Allocator) ![]u8 {
-    const name_len = try fileReadU32(file);
+fn readNcName(reader: *std.Io.File.Reader, allocator: std.mem.Allocator) ![]u8 {
+    const name_len = try fileReadU32(reader);
     if (name_len > MAX_NAME_LEN) return NcError.ReadError;
     const padded_len = (name_len + 3) & ~@as(u32, 3);
     const buf = allocator.alloc(u8, padded_len) catch return NcError.OutOfMemory;
     errdefer allocator.free(buf);
-    try readExact(file, buf);
+    try readExact(reader, buf);
     const result = allocator.alloc(u8, name_len) catch return NcError.OutOfMemory;
     @memcpy(result, buf[0..name_len]);
     allocator.free(buf);
@@ -473,11 +484,11 @@ fn readNcName(file: std.fs.File, allocator: std.mem.Allocator) ![]u8 {
 }
 
 /// Skip a NetCDF name without allocating.
-fn skipNcName(file: std.fs.File) !void {
-    const name_len = try fileReadU32(file);
+fn skipNcName(reader: *std.Io.File.Reader) !void {
+    const name_len = try fileReadU32(reader);
     if (name_len > MAX_NAME_LEN) return NcError.ReadError;
     const padded_len = (name_len + 3) & ~@as(u32, 3);
-    file.seekBy(@intCast(padded_len)) catch return NcError.ReadError;
+    reader.seekBy(@intCast(padded_len)) catch return NcError.ReadError;
 }
 
 // ============================================================================
@@ -494,7 +505,7 @@ pub const NcWriteError = error{
 ///
 /// Usage:
 ///
-///   var writer = try NcWriter.open(allocator, "output.nc", 100);
+///   var writer = try NcWriter.open(testIo(), allocator, "output.nc", 100);
 ///   defer writer.deinit();
 ///   for (frames) |frame| try writer.writeFrame(frame);
 ///   try writer.close();
@@ -502,7 +513,10 @@ pub const NcWriteError = error{
 /// Writes CDF-2 (64-bit offset) format with AMBER conventions.
 /// Coordinates must be in angstroms.
 pub const NcWriter = struct {
-    file: std.fs.File,
+    io: std.Io,
+    file: std.Io.File,
+    writer: std.Io.File.Writer,
+    write_buffer: []u8,
     allocator: std.mem.Allocator,
     n_atoms: u32,
     frames_written: u32,
@@ -521,21 +535,29 @@ pub const NcWriter = struct {
     const Self = @This();
 
     /// Create a new AMBER NetCDF trajectory file for writing.
-    pub fn open(allocator: std.mem.Allocator, path: []const u8, n_atoms: u32, has_cell: bool) !Self {
-        const file = std.fs.cwd().createFile(path, .{}) catch {
+    pub fn open(io: std.Io, allocator: std.mem.Allocator, path: []const u8, n_atoms: u32, has_cell: bool) !Self {
+        const file = std.Io.Dir.cwd().createFile(io, path, .{}) catch {
             return NcWriteError.FileCreateFailed;
         };
-        errdefer file.close();
+        errdefer file.close(io);
 
         const coord_bytes: usize = @as(usize, n_atoms) * 3 * 4;
         const coord_buf = allocator.alloc(u8, coord_bytes) catch return NcWriteError.OutOfMemory;
         errdefer allocator.free(coord_buf);
 
+        const write_buffer = allocator.alloc(u8, 64 * 1024) catch return NcWriteError.OutOfMemory;
+        errdefer allocator.free(write_buffer);
+
+        var writer = file.writer(io, write_buffer);
+
         // Write header
-        const header_info = writeHeader(file, n_atoms, has_cell) catch return NcWriteError.WriteError;
+        const header_info = writeHeader(&writer, n_atoms, has_cell) catch return NcWriteError.WriteError;
 
         return Self{
+            .io = io,
             .file = file,
+            .writer = writer,
+            .write_buffer = write_buffer,
             .allocator = allocator,
             .n_atoms = n_atoms,
             .frames_written = 0,
@@ -561,8 +583,8 @@ pub const NcWriter = struct {
             writeBEf32(self.coord_buf[base + 8 ..][0..4], frame.z[ai]);
         }
 
-        self.file.seekTo(file_offset) catch return NcWriteError.WriteError;
-        self.file.writeAll(self.coord_buf) catch return NcWriteError.WriteError;
+        self.writer.seekTo(file_offset) catch return NcWriteError.WriteError;
+        self.writer.interface.writeAll(self.coord_buf) catch return NcWriteError.WriteError;
 
         // Pad coordinates to 4-byte boundary
         const coord_bytes: u64 = @as(u64, n) * 12;
@@ -570,7 +592,7 @@ pub const NcWriter = struct {
         if (coord_padded > coord_bytes) {
             const zeros = [_]u8{ 0, 0, 0 };
             const pad_len: usize = @intCast(coord_padded - coord_bytes);
-            self.file.writeAll(zeros[0..pad_len]) catch return NcWriteError.WriteError;
+            self.writer.interface.writeAll(zeros[0..pad_len]) catch return NcWriteError.WriteError;
         }
 
         // Write cell data if present
@@ -605,8 +627,8 @@ pub const NcWriter = struct {
                 @memset(&abuf, 0);
             }
 
-            self.file.writeAll(&lbuf) catch return NcWriteError.WriteError;
-            self.file.writeAll(&abuf) catch return NcWriteError.WriteError;
+            self.writer.interface.writeAll(&lbuf) catch return NcWriteError.WriteError;
+            self.writer.interface.writeAll(&abuf) catch return NcWriteError.WriteError;
         }
 
         self.frames_written += 1;
@@ -617,14 +639,17 @@ pub const NcWriter = struct {
         defer {
             self.allocator.free(self.coord_buf);
             self.coord_buf = &.{};
-            self.file.close();
+            self.allocator.free(self.write_buffer);
+            self.write_buffer = &.{};
+            self.file.close(self.io);
             self.closed = true;
         }
         // Update numrecs (frame count) in the header
-        self.file.seekTo(self.numrecs_offset) catch return NcWriteError.WriteError;
+        self.writer.seekTo(self.numrecs_offset) catch return NcWriteError.WriteError;
         var buf: [4]u8 = undefined;
         std.mem.writeInt(u32, &buf, self.frames_written, .big);
-        self.file.writeAll(&buf) catch return NcWriteError.WriteError;
+        self.writer.interface.writeAll(&buf) catch return NcWriteError.WriteError;
+        self.writer.interface.flush() catch return NcWriteError.WriteError;
     }
 
     /// Best-effort cleanup if close() was not called.
@@ -642,66 +667,66 @@ const HeaderInfo = struct {
 };
 
 /// Write a complete AMBER NetCDF-3 (CDF-2) header.
-fn writeHeader(file: std.fs.File, n_atoms: u32, has_cell: bool) !HeaderInfo {
+fn writeHeader(writer: *std.Io.File.Writer, n_atoms: u32, has_cell: bool) !HeaderInfo {
 
     // Magic: CDF version 2 (64-bit offset)
-    try file.writeAll("CDF\x02");
+    try writer.interface.writeAll("CDF\x02");
 
     // numrecs (placeholder — updated on close)
     const numrecs_offset: u64 = 4;
-    try fileWriteU32(file, 0);
+    try fileWriteU32(writer, 0);
 
     // ---- Dimensions ----
     const n_dims: u32 = if (has_cell) 6 else 3;
-    try fileWriteU32(file, NC_DIMENSION);
-    try fileWriteU32(file, n_dims);
+    try fileWriteU32(writer, NC_DIMENSION);
+    try fileWriteU32(writer, n_dims);
 
     // dim 0: frame (unlimited)
-    try fileWriteName(file, "frame");
-    try fileWriteU32(file, 0); // 0 = unlimited
+    try fileWriteName(writer, "frame");
+    try fileWriteU32(writer, 0); // 0 = unlimited
 
     // dim 1: spatial
-    try fileWriteName(file, "spatial");
-    try fileWriteU32(file, 3);
+    try fileWriteName(writer, "spatial");
+    try fileWriteU32(writer, 3);
 
     // dim 2: atom
-    try fileWriteName(file, "atom");
-    try fileWriteU32(file, n_atoms);
+    try fileWriteName(writer, "atom");
+    try fileWriteU32(writer, n_atoms);
 
     if (has_cell) {
         // dim 3: cell_spatial
-        try fileWriteName(file, "cell_spatial");
-        try fileWriteU32(file, 3);
+        try fileWriteName(writer, "cell_spatial");
+        try fileWriteU32(writer, 3);
 
         // dim 4: label
-        try fileWriteName(file, "label");
-        try fileWriteU32(file, 5);
+        try fileWriteName(writer, "label");
+        try fileWriteU32(writer, 5);
 
         // dim 5: cell_angular
-        try fileWriteName(file, "cell_angular");
-        try fileWriteU32(file, 3);
+        try fileWriteName(writer, "cell_angular");
+        try fileWriteU32(writer, 3);
     }
 
     // ---- Global attributes ----
-    try fileWriteU32(file, NC_ATTRIBUTE);
-    try fileWriteU32(file, 2); // 2 attributes
+    try fileWriteU32(writer, NC_ATTRIBUTE);
+    try fileWriteU32(writer, 2); // 2 attributes
 
     // Conventions = "AMBER"
-    try fileWriteName(file, "Conventions");
-    try fileWriteU32(file, NC_CHAR);
-    try fileWriteU32(file, 5);
-    try file.writeAll("AMBER\x00\x00\x00"); // padded to 8 bytes
+    try fileWriteName(writer, "Conventions");
+    try fileWriteU32(writer, NC_CHAR);
+    try fileWriteU32(writer, 5);
+    try writer.interface.writeAll("AMBER\x00\x00\x00"); // padded to 8 bytes
 
     // ConventionVersion = "1.0"
-    try fileWriteName(file, "ConventionVersion");
-    try fileWriteU32(file, NC_CHAR);
-    try fileWriteU32(file, 3);
-    try file.writeAll("1.0\x00"); // padded to 4 bytes
+    try fileWriteName(writer, "ConventionVersion");
+    try fileWriteU32(writer, NC_CHAR);
+    try fileWriteU32(writer, 3);
+    try writer.interface.writeAll("1.0\x00"); // padded to 4 bytes
 
     // ---- Variables ----
     const n_vars: u32 = if (has_cell) 5 else 2;
-    try fileWriteU32(file, NC_VARIABLE);
-    try fileWriteU32(file, n_vars);
+    try fileWriteU32(writer, NC_VARIABLE);
+    try fileWriteU32(writer, n_vars);
 
     // Compute per-record sizes
     const coord_size: u64 = @as(u64, n_atoms) * 3 * 4;
@@ -740,86 +765,86 @@ fn writeHeader(file: std.fs.File, n_atoms: u32, has_cell: bool) !HeaderInfo {
     var vi: usize = 0;
 
     // var 0: spatial (non-record)
-    try fileWriteName(file, "spatial");
-    try fileWriteU32(file, 1); // 1 dim
-    try fileWriteU32(file, 1); // dimid=1 (spatial)
-    try fileWriteU32(file, 0); // no attrs tag
-    try fileWriteU32(file, 0); // no attrs count
-    try fileWriteU32(file, NC_CHAR);
-    try fileWriteU32(file, @intCast(spatial_size)); // vsize
-    var_defs[vi] = .{ .begin_file_pos = try file.getPos() };
-    try fileWriteU64(file, 0); // placeholder offset
+    try fileWriteName(writer, "spatial");
+    try fileWriteU32(writer, 1); // 1 dim
+    try fileWriteU32(writer, 1); // dimid=1 (spatial)
+    try fileWriteU32(writer, 0); // no attrs tag
+    try fileWriteU32(writer, 0); // no attrs count
+    try fileWriteU32(writer, NC_CHAR);
+    try fileWriteU32(writer, @intCast(spatial_size)); // vsize
+    var_defs[vi] = .{ .begin_file_pos = writer.logicalPos() };
+    try fileWriteU64(writer, 0); // placeholder offset
     vi += 1;
 
     // var 1: coordinates (record)
-    try fileWriteName(file, "coordinates");
-    try fileWriteU32(file, 3); // 3 dims
-    try fileWriteU32(file, 0); // dimid=0 (frame, unlimited)
-    try fileWriteU32(file, 2); // dimid=2 (atom)
-    try fileWriteU32(file, 1); // dimid=1 (spatial)
+    try fileWriteName(writer, "coordinates");
+    try fileWriteU32(writer, 3); // 3 dims
+    try fileWriteU32(writer, 0); // dimid=0 (frame, unlimited)
+    try fileWriteU32(writer, 2); // dimid=2 (atom)
+    try fileWriteU32(writer, 1); // dimid=1 (spatial)
     // 1 attribute: units = "angstrom"
-    try fileWriteU32(file, NC_ATTRIBUTE);
-    try fileWriteU32(file, 1);
-    try fileWriteName(file, "units");
-    try fileWriteU32(file, NC_CHAR);
-    try fileWriteU32(file, 8);
-    try file.writeAll("angstrom"); // 8 bytes, already aligned
-    try fileWriteU32(file, NC_FLOAT);
-    try fileWriteU32(file, @intCast(coord_padded)); // vsize
-    var_defs[vi] = .{ .begin_file_pos = try file.getPos() };
-    try fileWriteU64(file, 0); // placeholder
+    try fileWriteU32(writer, NC_ATTRIBUTE);
+    try fileWriteU32(writer, 1);
+    try fileWriteName(writer, "units");
+    try fileWriteU32(writer, NC_CHAR);
+    try fileWriteU32(writer, 8);
+    try writer.interface.writeAll("angstrom"); // 8 bytes, already aligned
+    try fileWriteU32(writer, NC_FLOAT);
+    try fileWriteU32(writer, @intCast(coord_padded)); // vsize
+    var_defs[vi] = .{ .begin_file_pos = writer.logicalPos() };
+    try fileWriteU64(writer, 0); // placeholder
     vi += 1;
 
     if (has_cell) {
         // var 2: cell_spatial (non-record)
-        try fileWriteName(file, "cell_spatial");
-        try fileWriteU32(file, 1); // 1 dim
-        try fileWriteU32(file, 3); // dimid=3 (cell_spatial)
-        try fileWriteU32(file, 0); // no attrs
-        try fileWriteU32(file, 0);
-        try fileWriteU32(file, NC_CHAR);
-        try fileWriteU32(file, 4); // vsize: 3 chars padded to 4
-        var_defs[vi] = .{ .begin_file_pos = try file.getPos() };
-        try fileWriteU64(file, 0);
+        try fileWriteName(writer, "cell_spatial");
+        try fileWriteU32(writer, 1); // 1 dim
+        try fileWriteU32(writer, 3); // dimid=3 (cell_spatial)
+        try fileWriteU32(writer, 0); // no attrs
+        try fileWriteU32(writer, 0);
+        try fileWriteU32(writer, NC_CHAR);
+        try fileWriteU32(writer, 4); // vsize: 3 chars padded to 4
+        var_defs[vi] = .{ .begin_file_pos = writer.logicalPos() };
+        try fileWriteU64(writer, 0);
         vi += 1;
 
         // var 3: cell_lengths (record)
-        try fileWriteName(file, "cell_lengths");
-        try fileWriteU32(file, 2); // 2 dims
-        try fileWriteU32(file, 0); // dimid=0 (frame)
-        try fileWriteU32(file, 3); // dimid=3 (cell_spatial)
-        try fileWriteU32(file, NC_ATTRIBUTE);
-        try fileWriteU32(file, 1);
-        try fileWriteName(file, "units");
-        try fileWriteU32(file, NC_CHAR);
-        try fileWriteU32(file, 8);
-        try file.writeAll("angstrom");
-        try fileWriteU32(file, NC_DOUBLE);
-        try fileWriteU32(file, @intCast(cell_lengths_size));
-        var_defs[vi] = .{ .begin_file_pos = try file.getPos() };
-        try fileWriteU64(file, 0);
+        try fileWriteName(writer, "cell_lengths");
+        try fileWriteU32(writer, 2); // 2 dims
+        try fileWriteU32(writer, 0); // dimid=0 (frame)
+        try fileWriteU32(writer, 3); // dimid=3 (cell_spatial)
+        try fileWriteU32(writer, NC_ATTRIBUTE);
+        try fileWriteU32(writer, 1);
+        try fileWriteName(writer, "units");
+        try fileWriteU32(writer, NC_CHAR);
+        try fileWriteU32(writer, 8);
+        try writer.interface.writeAll("angstrom");
+        try fileWriteU32(writer, NC_DOUBLE);
+        try fileWriteU32(writer, @intCast(cell_lengths_size));
+        var_defs[vi] = .{ .begin_file_pos = writer.logicalPos() };
+        try fileWriteU64(writer, 0);
         vi += 1;
 
         // var 4: cell_angles (record)
-        try fileWriteName(file, "cell_angles");
-        try fileWriteU32(file, 2); // 2 dims
-        try fileWriteU32(file, 0); // dimid=0 (frame)
-        try fileWriteU32(file, 5); // dimid=5 (cell_angular)
-        try fileWriteU32(file, NC_ATTRIBUTE);
-        try fileWriteU32(file, 1);
-        try fileWriteName(file, "units");
-        try fileWriteU32(file, NC_CHAR);
-        try fileWriteU32(file, 6);
-        try file.writeAll("degree\x00\x00"); // 6 chars padded to 8
-        try fileWriteU32(file, NC_DOUBLE);
-        try fileWriteU32(file, @intCast(cell_angles_size));
-        var_defs[vi] = .{ .begin_file_pos = try file.getPos() };
-        try fileWriteU64(file, 0);
+        try fileWriteName(writer, "cell_angles");
+        try fileWriteU32(writer, 2); // 2 dims
+        try fileWriteU32(writer, 0); // dimid=0 (frame)
+        try fileWriteU32(writer, 5); // dimid=5 (cell_angular)
+        try fileWriteU32(writer, NC_ATTRIBUTE);
+        try fileWriteU32(writer, 1);
+        try fileWriteName(writer, "units");
+        try fileWriteU32(writer, NC_CHAR);
+        try fileWriteU32(writer, 6);
+        try writer.interface.writeAll("degree\x00\x00"); // 6 chars padded to 8
+        try fileWriteU32(writer, NC_DOUBLE);
+        try fileWriteU32(writer, @intCast(cell_angles_size));
+        var_defs[vi] = .{ .begin_file_pos = writer.logicalPos() };
+        try fileWriteU64(writer, 0);
         vi += 1;
     }
 
     // Now we know where data starts
-    var data_offset = try file.getPos();
+    var data_offset = writer.logicalPos();
 
     // Non-record variables come first (spatial, cell_spatial)
     // var 0: spatial data at data_offset
@@ -844,46 +869,46 @@ fn writeHeader(file: std.fs.File, n_atoms: u32, has_cell: bool) !HeaderInfo {
     }
 
     // Write non-record data
-    file.seekTo(spatial_offset) catch return NcWriteError.WriteError;
-    try file.writeAll("xyz\x00"); // spatial labels padded to 4
+    writer.seekTo(spatial_offset) catch return NcWriteError.WriteError;
+    try writer.interface.writeAll("xyz\x00"); // spatial labels padded to 4
 
     if (has_cell) {
-        file.seekTo(cell_spatial_offset) catch return NcWriteError.WriteError;
-        try file.writeAll("abc\x00"); // cell_spatial labels
+        writer.seekTo(cell_spatial_offset) catch return NcWriteError.WriteError;
+        try writer.interface.writeAll("abc\x00"); // cell_spatial labels
     }
 
     // Fix up variable begin offsets
     vi = 0;
 
     // var 0: spatial
-    file.seekTo(var_defs[vi].begin_file_pos) catch return NcWriteError.WriteError;
-    try fileWriteU64(file, spatial_offset);
+    writer.seekTo(var_defs[vi].begin_file_pos) catch return NcWriteError.WriteError;
+    try fileWriteU64(writer, spatial_offset);
     vi += 1;
 
     // var 1: coordinates
-    file.seekTo(var_defs[vi].begin_file_pos) catch return NcWriteError.WriteError;
-    try fileWriteU64(file, coords_begin);
+    writer.seekTo(var_defs[vi].begin_file_pos) catch return NcWriteError.WriteError;
+    try fileWriteU64(writer, coords_begin);
     vi += 1;
 
     if (has_cell) {
         // var 2: cell_spatial
-        file.seekTo(var_defs[vi].begin_file_pos) catch return NcWriteError.WriteError;
-        try fileWriteU64(file, cell_spatial_offset);
+        writer.seekTo(var_defs[vi].begin_file_pos) catch return NcWriteError.WriteError;
+        try fileWriteU64(writer, cell_spatial_offset);
         vi += 1;
 
         // var 3: cell_lengths
-        file.seekTo(var_defs[vi].begin_file_pos) catch return NcWriteError.WriteError;
-        try fileWriteU64(file, cell_lengths_begin);
+        writer.seekTo(var_defs[vi].begin_file_pos) catch return NcWriteError.WriteError;
+        try fileWriteU64(writer, cell_lengths_begin);
         vi += 1;
 
         // var 4: cell_angles
-        file.seekTo(var_defs[vi].begin_file_pos) catch return NcWriteError.WriteError;
-        try fileWriteU64(file, cell_angles_begin);
+        writer.seekTo(var_defs[vi].begin_file_pos) catch return NcWriteError.WriteError;
+        try fileWriteU64(writer, cell_angles_begin);
         vi += 1;
     }
 
     // Seek to record data start for frame writing
-    file.seekTo(record_start) catch return NcWriteError.WriteError;
+    writer.seekTo(record_start) catch return NcWriteError.WriteError;
 
     return HeaderInfo{
         .numrecs_offset = numrecs_offset,
@@ -900,25 +925,25 @@ fn writeBEf64(buf: *[8]u8, val: f64) void {
     std.mem.writeInt(u64, buf, @bitCast(val), .big);
 }
 
-fn fileWriteU32(file: std.fs.File, val: u32) !void {
+fn fileWriteU32(writer: *std.Io.File.Writer, val: u32) !void {
     var buf: [4]u8 = undefined;
     std.mem.writeInt(u32, &buf, val, .big);
-    file.writeAll(&buf) catch return NcWriteError.WriteError;
+    writer.interface.writeAll(&buf) catch return NcWriteError.WriteError;
 }
 
-fn fileWriteU64(file: std.fs.File, val: u64) !void {
+fn fileWriteU64(writer: *std.Io.File.Writer, val: u64) !void {
     var buf: [8]u8 = undefined;
     std.mem.writeInt(u64, &buf, val, .big);
-    file.writeAll(&buf) catch return NcWriteError.WriteError;
+    writer.interface.writeAll(&buf) catch return NcWriteError.WriteError;
 }
 
-fn fileWriteName(file: std.fs.File, name: []const u8) !void {
-    try fileWriteU32(file, @intCast(name.len));
-    file.writeAll(name) catch return NcWriteError.WriteError;
+fn fileWriteName(writer: *std.Io.File.Writer, name: []const u8) !void {
+    try fileWriteU32(writer, @intCast(name.len));
+    writer.interface.writeAll(name) catch return NcWriteError.WriteError;
     const pad = (4 - (name.len % 4)) % 4;
     if (pad > 0) {
         const zeros = [_]u8{ 0, 0, 0 };
-        file.writeAll(zeros[0..pad]) catch return NcWriteError.WriteError;
+        writer.interface.writeAll(zeros[0..pad]) catch return NcWriteError.WriteError;
     }
 }
 
@@ -926,9 +951,16 @@ fn fileWriteName(file: std.fs.File, name: []const u8) !void {
 // Tests
 // ============================================================================
 
+fn testIo() std.Io {
+    const t = struct {
+        var threaded: std.Io.Threaded = .init_single_threaded;
+    };
+    return t.threaded.io();
+}
+
 test "open and read cpptraj nc (3 frames, 80 atoms, with cell)" {
     const allocator = std.testing.allocator;
-    var reader = try NcReader.open(allocator, "test_data/cpptraj_traj.nc");
+    var reader = try NcReader.open(testIo(), allocator, "test_data/cpptraj_traj.nc");
     defer reader.deinit();
 
     try std.testing.expectEqual(@as(u32, 80), reader.nAtoms());
@@ -972,7 +1004,7 @@ test "open and read cpptraj nc (3 frames, 80 atoms, with cell)" {
 
 test "open and read mdcrd nc (3 frames, 22 atoms, no cell)" {
     const allocator = std.testing.allocator;
-    var reader = try NcReader.open(allocator, "test_data/mdcrd.nc");
+    var reader = try NcReader.open(testIo(), allocator, "test_data/mdcrd.nc");
     defer reader.deinit();
 
     try std.testing.expectEqual(@as(u32, 22), reader.nAtoms());
@@ -1003,9 +1035,9 @@ test "open and read mdcrd nc (3 frames, 22 atoms, no cell)" {
 
 test "invalid nc file rejected" {
     const allocator = std.testing.allocator;
-    try std.testing.expectError(NcError.FileNotFound, NcReader.open(allocator, "test_data/nonexistent.nc"));
+    try std.testing.expectError(NcError.FileNotFound, NcReader.open(testIo(), allocator, "test_data/nonexistent.nc"));
     // A PDB file should fail magic check
-    try std.testing.expectError(NcError.InvalidMagic, NcReader.open(allocator, "test_data/1l2y.pdb"));
+    try std.testing.expectError(NcError.InvalidMagic, NcReader.open(testIo(), allocator, "test_data/1l2y.pdb"));
 }
 
 test "cellToVectors orthogonal box" {
@@ -1036,7 +1068,7 @@ test "cellToVectors degenerate gamma returns null" {
 
 test "next returns null after all frames read" {
     const allocator = std.testing.allocator;
-    var reader = try NcReader.open(allocator, "test_data/cpptraj_traj.nc");
+    var reader = try NcReader.open(testIo(), allocator, "test_data/cpptraj_traj.nc");
     defer reader.deinit();
 
     while (try reader.next()) |_| {}
@@ -1050,7 +1082,7 @@ test "NcWriter round-trip without cell" {
 
     // Write 2 frames of 3 atoms
     {
-        var writer = try NcWriter.open(allocator, tmp_path, 3, false);
+        var writer = try NcWriter.open(testIo(), allocator, tmp_path, 3, false);
         defer writer.deinit();
 
         var frame = try types.Frame.init(allocator, 3);
@@ -1073,10 +1105,10 @@ test "NcWriter round-trip without cell" {
         try writer.writeFrame(frame);
         try writer.close();
     }
-    defer std.fs.cwd().deleteFile(tmp_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(testIo(), tmp_path) catch {};
 
     // Read back and verify
-    var reader = try NcReader.open(allocator, tmp_path);
+    var reader = try NcReader.open(testIo(), allocator, tmp_path);
     defer reader.deinit();
 
     try std.testing.expectEqual(@as(u32, 3), reader.nAtoms());
@@ -1100,7 +1132,7 @@ test "NcWriter round-trip with cell" {
     const tmp_path = "test_data/_test_nc_roundtrip_cell.nc";
 
     {
-        var writer = try NcWriter.open(allocator, tmp_path, 2, true);
+        var writer = try NcWriter.open(testIo(), allocator, tmp_path, 2, true);
         defer writer.deinit();
 
         var frame = try types.Frame.init(allocator, 2);
@@ -1120,9 +1152,9 @@ test "NcWriter round-trip with cell" {
         try writer.writeFrame(frame);
         try writer.close();
     }
-    defer std.fs.cwd().deleteFile(tmp_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(testIo(), tmp_path) catch {};
 
-    var reader = try NcReader.open(allocator, tmp_path);
+    var reader = try NcReader.open(testIo(), allocator, tmp_path);
     defer reader.deinit();
 
     try std.testing.expectEqual(@as(u32, 2), reader.nAtoms());

--- a/src/io/nc.zig
+++ b/src/io/nc.zig
@@ -77,7 +77,7 @@ const VarInfo = struct {
 ///
 /// Usage:
 ///
-///   var reader = try NcReader.open(testIo(), allocator, "trajectory.nc");
+///   var reader = try NcReader.open(io, allocator, "trajectory.nc");
 ///   defer reader.deinit();
 ///
 ///   while (try reader.next()) |frame| {
@@ -505,7 +505,7 @@ pub const NcWriteError = error{
 ///
 /// Usage:
 ///
-///   var writer = try NcWriter.open(testIo(), allocator, "output.nc", 100);
+///   var writer = try NcWriter.open(io, allocator, "output.nc", 100);
 ///   defer writer.deinit();
 ///   for (frames) |frame| try writer.writeFrame(frame);
 ///   try writer.close();

--- a/src/io/pdb.zig
+++ b/src/io/pdb.zig
@@ -176,12 +176,12 @@ pub fn parse(allocator: std.mem.Allocator, data: []const u8) !types.ParseResult 
     // -------------------------------------------------------------------------
     // Pass 1: collect raw atoms and CONECT entries
     // -------------------------------------------------------------------------
-    var raw_atoms = std.ArrayListUnmanaged(RawAtom){};
+    var raw_atoms = std.ArrayList(RawAtom).empty;
     defer raw_atoms.deinit(allocator);
 
     // CONECT: list of (serial_i, serial_j) pairs
     const ConectPair = struct { i: u32, j: u32 };
-    var conect_pairs = std.ArrayListUnmanaged(ConectPair){};
+    var conect_pairs = std.ArrayList(ConectPair).empty;
     defer conect_pairs.deinit(allocator);
 
     var first_alt_loc: u8 = 0; // 0 = not yet set
@@ -295,7 +295,7 @@ pub fn parse(allocator: std.mem.Allocator, data: []const u8) !types.ParseResult 
     const n_atoms: u32 = @intCast(raw_atoms.items.len);
 
     // Build serial -> atom_index map for CONECT resolution
-    var serial_to_idx = std.AutoHashMapUnmanaged(u32, u32){};
+    var serial_to_idx = std.AutoHashMapUnmanaged(u32, u32).empty;
     defer serial_to_idx.deinit(allocator);
     try serial_to_idx.ensureTotalCapacity(allocator, n_atoms);
     for (raw_atoms.items, 0..) |ra, i| {
@@ -304,7 +304,7 @@ pub fn parse(allocator: std.mem.Allocator, data: []const u8) !types.ParseResult 
 
     // Deduplicate CONECT bonds
     const BondKey = struct { i: u32, j: u32 };
-    var bond_set = std.AutoHashMapUnmanaged(BondKey, void){};
+    var bond_set = std.AutoHashMapUnmanaged(BondKey, void).empty;
     defer bond_set.deinit(allocator);
     for (conect_pairs.items) |cp| {
         const idx_i = serial_to_idx.get(cp.i) orelse continue;
@@ -669,7 +669,7 @@ test "write PDB round-trip" {
     defer result.deinit();
 
     // Write to buffer
-    var buf = std.ArrayListUnmanaged(u8){};
+    var buf = std.ArrayList(u8).empty;
     defer buf.deinit(allocator);
     try write(buf.writer(allocator), result.topology, result.frame);
 

--- a/src/io/pdb.zig
+++ b/src/io/pdb.zig
@@ -669,12 +669,12 @@ test "write PDB round-trip" {
     defer result.deinit();
 
     // Write to buffer
-    var buf = std.ArrayList(u8).empty;
-    defer buf.deinit(allocator);
-    try write(buf.writer(allocator), result.topology, result.frame);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    try write(&aw.writer, result.topology, result.frame);
 
     // Parse the written output
-    var result2 = try parse(allocator, buf.items);
+    var result2 = try parse(allocator, aw.written());
     defer result2.deinit();
 
     // Compare

--- a/src/io/prmtop.zig
+++ b/src/io/prmtop.zig
@@ -64,8 +64,8 @@ const FortranFormat = struct {
 /// We only need the field width for fixed-width slicing.
 fn parseFortranFormat(fmt_line: []const u8) ?FortranFormat {
     // Find content between parentheses
-    const open = std.mem.indexOfScalar(u8, fmt_line, '(') orelse return null;
-    const close = std.mem.indexOfScalar(u8, fmt_line, ')') orelse return null;
+    const open = std.mem.findScalar(u8, fmt_line, '(') orelse return null;
+    const close = std.mem.findScalar(u8, fmt_line, ')') orelse return null;
     if (close <= open + 1) return null;
     const inner = fmt_line[open + 1 .. close];
 
@@ -120,7 +120,7 @@ pub fn parseTopology(allocator: std.mem.Allocator, data: []const u8) !types.Topo
     // -------------------------------------------------------------------------
     var lines = std.mem.splitScalar(u8, data, '\n');
     const first_line = lines.next() orelse return ParseError.InvalidFormat;
-    const first_trimmed = std.mem.trimRight(u8, first_line, "\r ");
+    const first_trimmed = std.mem.trimEnd(u8, first_line, "\r ");
     if (!std.mem.startsWith(u8, first_trimmed, "%VERSION")) {
         return ParseError.InvalidFormat;
     }
@@ -145,7 +145,7 @@ pub fn parseTopology(allocator: std.mem.Allocator, data: []const u8) !types.Topo
     var byte_offset: usize = 0;
 
     while (line_iter.next()) |line| {
-        const trimmed = std.mem.trimRight(u8, line, "\r");
+        const trimmed = std.mem.trimEnd(u8, line, "\r");
         const line_end = byte_offset + line.len + 1; // +1 for \n
 
         if (std.mem.startsWith(u8, trimmed, "%FLAG")) {
@@ -162,8 +162,8 @@ pub fn parseTopology(allocator: std.mem.Allocator, data: []const u8) !types.Topo
                 }
             }
             // Extract flag name
-            const rest = std.mem.trimLeft(u8, trimmed[5..], " ");
-            const flag_end = std.mem.indexOfAny(u8, rest, " \t") orelse rest.len;
+            const rest = std.mem.trimStart(u8, trimmed[5..], " ");
+            const flag_end = std.mem.findAny(u8, rest, " \t") orelse rest.len;
             current_flag = rest[0..flag_end];
             current_format = null;
             data_start = null;
@@ -207,7 +207,7 @@ pub fn parseTopology(allocator: std.mem.Allocator, data: []const u8) !types.Topo
         var ptr_lines = std.mem.splitScalar(u8, sec_data, '\n');
         var ptr_idx: usize = 0;
         while (ptr_lines.next()) |pline| {
-            const ptrimmed = std.mem.trimRight(u8, pline, "\r ");
+            const ptrimmed = std.mem.trimEnd(u8, pline, "\r ");
             if (ptrimmed.len == 0) continue;
             if (std.mem.startsWith(u8, ptrimmed, "%")) break;
             const width = pointers_sec.format.width;
@@ -240,7 +240,7 @@ pub fn parseTopology(allocator: std.mem.Allocator, data: []const u8) !types.Topo
         const Self = @This();
 
         fn items(self: Self, allocator_: std.mem.Allocator, expected: u32) ![][]const u8 {
-            var result = std.ArrayListUnmanaged([]const u8){};
+            var result = std.ArrayList([]const u8).empty;
             errdefer result.deinit(allocator_);
 
             if (expected > 0) {
@@ -249,7 +249,7 @@ pub fn parseTopology(allocator: std.mem.Allocator, data: []const u8) !types.Topo
 
             var sec_lines = std.mem.splitScalar(u8, self.sec_data, '\n');
             while (sec_lines.next()) |sline| {
-                const strimmed = std.mem.trimRight(u8, sline, "\r");
+                const strimmed = std.mem.trimEnd(u8, sline, "\r");
                 if (strimmed.len == 0) continue;
                 if (std.mem.startsWith(u8, strimmed, "%")) break;
                 var col: usize = 0;
@@ -366,7 +366,7 @@ pub fn parseTopology(allocator: std.mem.Allocator, data: []const u8) !types.Topo
     // Parse bond sections
     // -------------------------------------------------------------------------
     const BondRaw = struct { atom_i: u32, atom_j: u32 };
-    var bonds_list = std.ArrayListUnmanaged(BondRaw){};
+    var bonds_list = std.ArrayList(BondRaw).empty;
     defer bonds_list.deinit(allocator);
     try bonds_list.ensureTotalCapacity(allocator, n_bonds);
 
@@ -544,8 +544,15 @@ test "inferElement atom names" {
     try std.testing.expectEqual(elem.Element.H, inferElement("H1"));
 }
 
+fn testIo() std.Io {
+    const t = struct {
+        var threaded: std.Io.Threaded = .init_single_threaded;
+    };
+    return t.threaded.io();
+}
+
 fn readTestFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
-    return std.fs.cwd().readFileAlloc(allocator, path, 16 * 1024 * 1024);
+    return std.Io.Dir.cwd().readFileAlloc(testIo(), path, allocator, .limited(16 * 1024 * 1024));
 }
 
 test "parse alanine dipeptide implicit prmtop" {

--- a/src/io/trr.zig
+++ b/src/io/trr.zig
@@ -27,7 +27,7 @@ pub const TrrReadError = error{
 ///
 /// Usage:
 ///
-///   var reader = try TrrReader.open(allocator, "trajectory.trr");
+///   var reader = try TrrReader.open(io, allocator, "trajectory.trr");
 ///   defer reader.deinit();
 ///
 ///   while (try reader.next()) |frame| {
@@ -131,7 +131,7 @@ pub const TrrReader = struct {
 ///
 /// Usage:
 ///
-///   var writer = try TrrWriter.open(allocator, "trajectory.trr", n_atoms);
+///   var writer = try TrrWriter.open(io, allocator, "trajectory.trr", n_atoms);
 ///   defer writer.deinit();
 ///
 ///   try writer.writeFrame(frame);
@@ -213,8 +213,15 @@ pub const TrrWriter = struct {
 // Tests
 // ============================================================================
 
+fn testIo() std.Io {
+    const t = struct {
+        var threaded: std.Io.Threaded = .init_single_threaded;
+    };
+    return t.threaded.io();
+}
+
 test "TrrReader: missing file returns FileNotFound" {
     const allocator = std.testing.allocator;
-    const result = TrrReader.open(allocator, "nonexistent_file.trr");
+    const result = TrrReader.open(testIo(), allocator, "nonexistent_file.trr");
     try std.testing.expectError(TrrReadError.FileNotFound, result);
 }

--- a/src/io/trr.zig
+++ b/src/io/trr.zig
@@ -44,8 +44,8 @@ pub const TrrReader = struct {
     const Self = @This();
 
     /// Open a TRR file for reading.
-    pub fn open(allocator: std.mem.Allocator, path: []const u8) !Self {
-        var inner = TrrReaderInner.open(allocator, path) catch |err| {
+    pub fn open(io: std.Io, allocator: std.mem.Allocator, path: []const u8) !Self {
+        var inner = TrrReaderInner.open(io, allocator, path) catch |err| {
             return switch (err) {
                 TrrError.FileNotFound => TrrReadError.FileNotFound,
                 TrrError.InvalidMagic => TrrReadError.InvalidMagic,
@@ -148,9 +148,9 @@ pub const TrrWriter = struct {
 
     const Self = @This();
 
-    pub fn open(allocator: std.mem.Allocator, path: []const u8, n_atoms: usize) !Self {
+    pub fn open(io: std.Io, allocator: std.mem.Allocator, path: []const u8, n_atoms: usize) !Self {
         const natoms_i: i32 = @intCast(n_atoms);
-        var inner = try TrrWriterInner.open(allocator, path, natoms_i, .write);
+        var inner = try TrrWriterInner.open(io, allocator, path, natoms_i, .write);
         errdefer inner.close() catch {};
         const coords_buf = try allocator.alloc(f32, n_atoms * 3);
         return Self{ .inner = inner, .coords_buf = coords_buf, .allocator = allocator };

--- a/src/io/xtc.zig
+++ b/src/io/xtc.zig
@@ -26,7 +26,7 @@ pub const XtcReadError = error{
 ///
 /// Usage:
 ///
-///   var reader = try XtcReader.open(allocator, "trajectory.xtc");
+///   var reader = try XtcReader.open(io, allocator, "trajectory.xtc");
 ///   defer reader.deinit();
 ///
 ///   while (try reader.next()) |frame| {
@@ -130,7 +130,7 @@ pub const XtcReader = struct {
 ///
 /// Usage:
 ///
-///   var writer = try XtcWriter.open(allocator, "trajectory.xtc", n_atoms);
+///   var writer = try XtcWriter.open(io, allocator, "trajectory.xtc", n_atoms);
 ///   defer writer.deinit();
 ///
 ///   try writer.writeFrame(frame);
@@ -206,17 +206,24 @@ pub const XtcWriter = struct {
 // Tests
 // ============================================================================
 
+fn testIo() std.Io {
+    const t = struct {
+        var threaded: std.Io.Threaded = .init_single_threaded;
+    };
+    return t.threaded.io();
+}
+
 test "XtcReader compiles and can be deinitialized with no file" {
     // Verify the struct layout is correct without requiring a real XTC file.
     // Structural integrity only — open() will fail gracefully on missing file.
     const allocator = std.testing.allocator;
 
-    const result = XtcReader.open(allocator, "nonexistent_file.xtc");
+    const result = XtcReader.open(testIo(), allocator, "nonexistent_file.xtc");
     try std.testing.expectError(XtcReadError.FileNotFound, result);
 }
 
 test "XtcReader open error is FileNotFound for missing path" {
     const allocator = std.testing.allocator;
-    const err = XtcReader.open(allocator, "/no/such/path/trajectory.xtc");
+    const err = XtcReader.open(testIo(), allocator, "/no/such/path/trajectory.xtc");
     try std.testing.expectError(XtcReadError.FileNotFound, err);
 }

--- a/src/io/xtc.zig
+++ b/src/io/xtc.zig
@@ -48,8 +48,8 @@ pub const XtcReader = struct {
     ///
     /// Allocates a single Frame buffer sized to the number of atoms in the file.
     /// Returns error.FileNotFound if the path does not exist.
-    pub fn open(allocator: std.mem.Allocator, path: []const u8) !Self {
-        var inner = XtcReaderInner.open(allocator, path) catch |err| {
+    pub fn open(io: std.Io, allocator: std.mem.Allocator, path: []const u8) !Self {
+        var inner = XtcReaderInner.open(io, allocator, path) catch |err| {
             return switch (err) {
                 XtcError.FileNotFound => XtcReadError.FileNotFound,
                 XtcError.InvalidMagic => XtcReadError.InvalidMagic,
@@ -146,9 +146,9 @@ pub const XtcWriter = struct {
 
     const Self = @This();
 
-    pub fn open(allocator: std.mem.Allocator, path: []const u8, n_atoms: usize) !Self {
+    pub fn open(io: std.Io, allocator: std.mem.Allocator, path: []const u8, n_atoms: usize) !Self {
         const natoms_i: i32 = @intCast(n_atoms);
-        var inner = try XtcWriterInner.open(allocator, path, natoms_i, .write);
+        var inner = try XtcWriterInner.open(io, allocator, path, natoms_i, .write);
         errdefer inner.close() catch {};
         const coords_buf = try allocator.alloc(f32, n_atoms * 3);
         return Self{ .inner = inner, .coords_buf = coords_buf, .allocator = allocator };

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,13 +9,12 @@ const build_options = @import("build_options");
 const cli_args = @import("cli/args.zig");
 const runners = @import("cli/runners.zig");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const io = init.io;
 
-    const raw_args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, raw_args);
+    const args_z = try init.minimal.args.toSlice(init.arena.allocator());
+    const raw_args: []const []const u8 = @ptrCast(args_z);
 
     if (raw_args.len < 2) {
         cli_args.printUsage(raw_args[0]);
@@ -25,10 +24,10 @@ pub fn main() !void {
     const first = raw_args[1];
 
     if (std.mem.eql(u8, first, "--version") or std.mem.eql(u8, first, "-V")) {
-        const stdout = std.fs.File.stdout();
+        const stdout = std.Io.File.stdout();
         var buf: [64]u8 = undefined;
         const line = try std.fmt.bufPrint(&buf, "ztraj {s}\n", .{build_options.version});
-        try stdout.writeAll(line);
+        try stdout.writeStreamingAll(io, line);
         return;
     }
     if (std.mem.eql(u8, first, "--help") or std.mem.eql(u8, first, "-h")) {
@@ -51,26 +50,26 @@ pub fn main() !void {
     };
 
     const result = switch (args.subcommand) {
-        .rmsd => runners.runRmsd(allocator, args),
-        .rmsf => runners.runRmsf(allocator, args),
-        .distances => runners.runDistances(allocator, args),
-        .angles => runners.runAngles(allocator, args),
-        .dihedrals => runners.runDihedrals(allocator, args),
-        .rg => runners.runRg(allocator, args),
-        .center => runners.runCenter(allocator, args),
-        .inertia => runners.runInertia(allocator, args),
-        .hbonds => runners.runHbonds(allocator, args),
-        .contacts => runners.runContacts(allocator, args),
-        .rdf => runners.runRdf(allocator, args),
-        .sasa => runners.runSasa(allocator, args),
-        .all => runners.runAll(allocator, args),
-        .dssp => runners.runDssp(allocator, args),
-        .phi => runners.runPhi(allocator, args),
-        .psi => runners.runPsi(allocator, args),
-        .omega => runners.runOmega(allocator, args),
-        .chi => runners.runChi(allocator, args),
-        .summary => runners.runSummary(allocator, args),
-        .convert => runners.runConvert(allocator, args),
+        .rmsd => runners.runRmsd(io, allocator, args),
+        .rmsf => runners.runRmsf(io, allocator, args),
+        .distances => runners.runDistances(io, allocator, args),
+        .angles => runners.runAngles(io, allocator, args),
+        .dihedrals => runners.runDihedrals(io, allocator, args),
+        .rg => runners.runRg(io, allocator, args),
+        .center => runners.runCenter(io, allocator, args),
+        .inertia => runners.runInertia(io, allocator, args),
+        .hbonds => runners.runHbonds(io, allocator, args),
+        .contacts => runners.runContacts(io, allocator, args),
+        .rdf => runners.runRdf(io, allocator, args),
+        .sasa => runners.runSasa(io, allocator, args),
+        .all => runners.runAll(io, allocator, args),
+        .dssp => runners.runDssp(io, allocator, args),
+        .phi => runners.runPhi(io, allocator, args),
+        .psi => runners.runPsi(io, allocator, args),
+        .omega => runners.runOmega(io, allocator, args),
+        .chi => runners.runChi(io, allocator, args),
+        .summary => runners.runSummary(io, allocator, args),
+        .convert => runners.runConvert(io, allocator, args),
     };
 
     result catch |err| {

--- a/src/mmap_reader.zig
+++ b/src/mmap_reader.zig
@@ -22,22 +22,22 @@ pub const MappedFile = struct {
     }
 };
 
-pub fn mmapFile(allocator: std.mem.Allocator, path: []const u8) !MappedFile {
-    const file = try std.fs.cwd().openFile(path, .{});
-    defer file.close();
+pub fn mmapFile(io: std.Io, allocator: std.mem.Allocator, path: []const u8) !MappedFile {
+    const file = try std.Io.Dir.cwd().openFile(io, path, .{});
+    defer file.close(io);
 
-    const stat = try file.stat();
+    const stat = try file.stat(io);
     const size: usize = std.math.cast(usize, stat.size) orelse return error.FileTooBig;
     if (size == 0) return .{ .data = &.{}, .allocator = if (is_windows) allocator else {} };
 
     if (is_windows) {
-        const data = try file.readToEndAlloc(allocator, size);
+        const data = try std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(size));
         return .{ .data = data, .allocator = allocator };
     } else {
         const mapped = try std.posix.mmap(
             null,
             size,
-            std.posix.PROT.READ,
+            .{ .READ = true },
             .{ .TYPE = .PRIVATE },
             file.handle,
             0,
@@ -46,8 +46,15 @@ pub fn mmapFile(allocator: std.mem.Allocator, path: []const u8) !MappedFile {
     }
 }
 
+fn testIo() std.Io {
+    const t = struct {
+        var threaded: std.Io.Threaded = .init_single_threaded;
+    };
+    return t.threaded.io();
+}
+
 test "mmapFile reads valid PDB" {
-    const mapped = mmapFile(std.testing.allocator, "test_data/1l2y.pdb") catch |err| {
+    const mapped = mmapFile(testIo(), std.testing.allocator, "test_data/1l2y.pdb") catch |err| {
         if (err == error.FileNotFound) return; // Skip when run from non-project-root cwd
         return err;
     };

--- a/src/mmap_reader.zig
+++ b/src/mmap_reader.zig
@@ -31,8 +31,11 @@ pub fn mmapFile(io: std.Io, allocator: std.mem.Allocator, path: []const u8) !Map
     if (size == 0) return .{ .data = &.{}, .allocator = if (is_windows) allocator else {} };
 
     if (is_windows) {
-        const data = try std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(size));
-        return .{ .data = data, .allocator = allocator };
+        // Read from the already-open handle to avoid a TOCTOU re-open.
+        const data = try allocator.alloc(u8, size);
+        errdefer allocator.free(data);
+        const n = try file.readPositionalAll(io, data, 0);
+        return .{ .data = data[0..n], .allocator = allocator };
     } else {
         const mapped = try std.posix.mmap(
             null,

--- a/src/output.zig
+++ b/src/output.zig
@@ -125,8 +125,8 @@ fn writeJsonEscaped(writer: anytype, s: []const u8) !void {
 test "writeDelimited CSV with header and rows" {
     const allocator = std.testing.allocator;
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
 
     const headers = [_][]const u8{ "frame", "rmsd", "rg" };
     const row0 = [_]f64{ 0.0, 1.23456, 7.89012 };
@@ -136,113 +136,113 @@ test "writeDelimited CSV with header and rows" {
         &row1,
     };
 
-    try writeDelimited(buf.writer(allocator), &headers, &rows, ',');
+    try writeDelimited(&aw.writer, &headers, &rows, ',');
 
-    const output = buf.items;
+    const output = aw.written();
     try std.testing.expect(std.mem.startsWith(u8, output, "frame,rmsd,rg\n"));
-    try std.testing.expect(std.mem.indexOf(u8, output, "0.000000,1.234560,7.890120\n") != null);
-    try std.testing.expect(std.mem.indexOf(u8, output, "1.000000,2.345670,8.901230\n") != null);
+    try std.testing.expect(std.mem.find(u8, output, "0.000000,1.234560,7.890120\n") != null);
+    try std.testing.expect(std.mem.find(u8, output, "1.000000,2.345670,8.901230\n") != null);
 }
 
 test "writeDelimited TSV uses tab delimiter" {
     const allocator = std.testing.allocator;
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
 
     const headers = [_][]const u8{ "a", "b" };
     const row = [_]f64{ 1.0, 2.0 };
     const rows = [_][]const f64{&row};
 
-    try writeDelimited(buf.writer(allocator), &headers, &rows, '\t');
+    try writeDelimited(&aw.writer, &headers, &rows, '\t');
 
-    const output = buf.items;
+    const output = aw.written();
     try std.testing.expect(std.mem.startsWith(u8, output, "a\tb\n"));
-    try std.testing.expect(std.mem.indexOf(u8, output, "\t") != null);
+    try std.testing.expect(std.mem.find(u8, output, "\t") != null);
     // Must not contain commas.
-    try std.testing.expect(std.mem.indexOf(u8, output, ",") == null);
+    try std.testing.expect(std.mem.find(u8, output, ",") == null);
 }
 
 test "writeDelimited empty rows only writes header" {
     const allocator = std.testing.allocator;
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
 
     const headers = [_][]const u8{ "x", "y" };
     const rows = [_][]const f64{};
 
-    try writeDelimited(buf.writer(allocator), &headers, &rows, ',');
+    try writeDelimited(&aw.writer, &headers, &rows, ',');
 
-    try std.testing.expectEqualStrings("x,y\n", buf.items);
+    try std.testing.expectEqualStrings("x,y\n", aw.written());
 }
 
 test "writeJsonArray produces valid JSON array" {
     const allocator = std.testing.allocator;
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
 
     const values = [_]f64{ 1.0, 2.5, 3.14159 };
-    try writeJsonArray(buf.writer(allocator), "rmsd", &values);
+    try writeJsonArray(&aw.writer, "rmsd", &values);
 
-    const output = buf.items;
+    const output = aw.written();
     try std.testing.expect(std.mem.startsWith(u8, output, "\"rmsd\": ["));
     try std.testing.expect(std.mem.endsWith(u8, output, "]"));
-    try std.testing.expect(std.mem.indexOf(u8, output, "1.000000") != null);
-    try std.testing.expect(std.mem.indexOf(u8, output, "3.141590") != null);
+    try std.testing.expect(std.mem.find(u8, output, "1.000000") != null);
+    try std.testing.expect(std.mem.find(u8, output, "3.141590") != null);
 }
 
 test "writeJsonObject produces valid JSON object" {
     const allocator = std.testing.allocator;
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
 
     const keys = [_][]const u8{ "rmsd", "rg" };
     const rmsd_vals = [_]f64{ 0.5, 1.0 };
     const rg_vals = [_]f64{ 10.0, 11.0 };
     const values = [_][]const f64{ &rmsd_vals, &rg_vals };
 
-    try writeJsonObject(buf.writer(allocator), &keys, &values);
+    try writeJsonObject(&aw.writer, &keys, &values);
 
-    const output = buf.items;
+    const output = aw.written();
     try std.testing.expect(std.mem.startsWith(u8, output, "{\n"));
     try std.testing.expect(std.mem.endsWith(u8, output, "}"));
-    try std.testing.expect(std.mem.indexOf(u8, output, "\"rmsd\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, output, "\"rg\"") != null);
+    try std.testing.expect(std.mem.find(u8, output, "\"rmsd\"") != null);
+    try std.testing.expect(std.mem.find(u8, output, "\"rg\"") != null);
     // Second key should NOT have a trailing comma.
-    const rg_pos = std.mem.indexOf(u8, output, "\"rg\"").?;
+    const rg_pos = std.mem.find(u8, output, "\"rg\"").?;
     const after_rg = output[rg_pos..];
-    try std.testing.expect(std.mem.indexOf(u8, after_rg, "],") == null);
+    try std.testing.expect(std.mem.find(u8, after_rg, "],") == null);
 }
 
 test "writeJsonArray with empty values" {
     const allocator = std.testing.allocator;
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
 
     const values = [_]f64{};
-    try writeJsonArray(buf.writer(allocator), "empty", &values);
+    try writeJsonArray(&aw.writer, "empty", &values);
 
-    try std.testing.expectEqualStrings("\"empty\": []", buf.items);
+    try std.testing.expectEqualStrings("\"empty\": []", aw.written());
 }
 
 test "writeJsonObject with single key" {
     const allocator = std.testing.allocator;
 
-    var buf = std.ArrayList(u8){};
-    defer buf.deinit(allocator);
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
 
     const keys = [_][]const u8{"x"};
     const vals = [_]f64{42.0};
     const values = [_][]const f64{&vals};
 
-    try writeJsonObject(buf.writer(allocator), &keys, &values);
+    try writeJsonObject(&aw.writer, &keys, &values);
 
-    const output = buf.items;
+    const output = aw.written();
     // Single key must not have a trailing comma before the closing newline.
-    try std.testing.expect(std.mem.indexOf(u8, output, "],") == null);
-    try std.testing.expect(std.mem.indexOf(u8, output, "42.000000") != null);
+    try std.testing.expect(std.mem.find(u8, output, "],") == null);
+    try std.testing.expect(std.mem.find(u8, output, "42.000000") != null);
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -54,10 +54,14 @@ pub const dssp = @import("analysis/dssp/dssp.zig");
 
 test {
     // Use refAllDecls (non-recursive) to avoid pulling dssp's test suite
-    // and pdb.zig's @embedFile path issues
+    // and pdb.zig's @embedFile path issues (which go outside the package root).
     @import("std").testing.refAllDecls(@This());
-    // Explicitly pull in parser tests (not reached by non-recursive refAllDecls)
+    // Explicitly pull in module tests (not reached by non-recursive refAllDecls).
     _ = io.gro;
     _ = io.prmtop;
     _ = io.nc;
+    _ = io.dcd;
+    _ = io.xtc;
+    _ = io.trr;
+    _ = io.mmcif;
 }

--- a/src/select.zig
+++ b/src/select.zig
@@ -61,7 +61,7 @@ const water_residues = [_][]const u8{
 /// Returns error.InvalidSpec if the string is malformed.
 /// Caller owns the returned slice.
 pub fn byIndex(allocator: std.mem.Allocator, spec: []const u8) ![]u32 {
-    var result = std.ArrayList(u32){};
+    var result = std.ArrayList(u32).empty;
     defer result.deinit(allocator);
 
     var token_iter = std.mem.tokenizeScalar(u8, spec, ',');
@@ -69,7 +69,7 @@ pub fn byIndex(allocator: std.mem.Allocator, spec: []const u8) ![]u32 {
         const trimmed = std.mem.trim(u8, token, " \t\r\n");
         if (trimmed.len == 0) continue;
 
-        if (std.mem.indexOfScalar(u8, trimmed, '-')) |dash_pos| {
+        if (std.mem.findScalar(u8, trimmed, '-')) |dash_pos| {
             // Range: "start-end"
             const start_str = std.mem.trim(u8, trimmed[0..dash_pos], " ");
             const end_str = std.mem.trim(u8, trimmed[dash_pos + 1 ..], " ");
@@ -121,7 +121,7 @@ pub fn byKeyword(
     topology: types.Topology,
     kw: Keyword,
 ) ![]u32 {
-    var result = std.ArrayList(u32){};
+    var result = std.ArrayList(u32).empty;
     defer result.deinit(allocator);
 
     switch (kw) {
@@ -193,7 +193,7 @@ pub fn byName(
     topology: types.Topology,
     name: []const u8,
 ) ![]u32 {
-    var result = std.ArrayList(u32){};
+    var result = std.ArrayList(u32).empty;
     defer result.deinit(allocator);
 
     for (topology.atoms, 0..) |atom, i| {
@@ -216,7 +216,7 @@ pub fn byElement(
     topology: types.Topology,
     elem: Element,
 ) ![]u32 {
-    var result = std.ArrayList(u32){};
+    var result = std.ArrayList(u32).empty;
     defer result.deinit(allocator);
 
     for (topology.atoms, 0..) |atom, i| {

--- a/src/simd/lee_richards.zig
+++ b/src/simd/lee_richards.zig
@@ -62,9 +62,10 @@ pub fn sliceRadiiBatch4(
 
     // Clamp negative values to 0 (no intersection)
     const zero: @Vector(4, f64) = @splat(0.0);
-    const rp_sq_clamped = @max(rp_sq, zero);
+    const rp_sq_clamped: @Vector(4, f64) = @max(rp_sq, zero);
 
-    return @sqrt(rp_sq_clamped);
+    const result: @Vector(4, f64) = @sqrt(rp_sq_clamped);
+    return result;
 }
 
 /// Check if circles overlap (dij < Ri' + Rj') for 4 neighbors.
@@ -149,9 +150,10 @@ pub fn sliceRadiiBatch8(
 
     // Clamp negative values to 0 (no intersection)
     const zero: @Vector(8, f64) = @splat(0.0);
-    const rp_sq_clamped = @max(rp_sq, zero);
+    const rp_sq_clamped: @Vector(8, f64) = @max(rp_sq, zero);
 
-    return @sqrt(rp_sq_clamped);
+    const result: @Vector(8, f64) = @sqrt(rp_sq_clamped);
+    return result;
 }
 
 /// Check if circles overlap (dij < Ri' + Rj') for 8 neighbors.
@@ -200,8 +202,9 @@ pub fn xyDistanceBatch4Gen(comptime T: type) type {
             const dx = nx - px;
             const dy = ny - py;
 
-            const dist_sq = dx * dx + dy * dy;
-            return @sqrt(dist_sq);
+            const dist_sq: @Vector(4, T) = dx * dx + dy * dy;
+            const result: @Vector(4, T) = @sqrt(dist_sq);
+            return result;
         }
     };
 }
@@ -225,9 +228,10 @@ pub fn sliceRadiiBatch4Gen(comptime T: type) type {
             const rp_sq = r_sq - dz_sq;
 
             const zero: @Vector(4, T) = @splat(0.0);
-            const rp_sq_clamped = @max(rp_sq, zero);
+            const rp_sq_clamped: @Vector(4, T) = @max(rp_sq, zero);
 
-            return @sqrt(rp_sq_clamped);
+            const result: @Vector(4, T) = @sqrt(rp_sq_clamped);
+            return result;
         }
     };
 }
@@ -270,8 +274,9 @@ pub fn xyDistanceBatch8Gen(comptime T: type) type {
             const dx = nx - px;
             const dy = ny - py;
 
-            const dist_sq = dx * dx + dy * dy;
-            return @sqrt(dist_sq);
+            const dist_sq: @Vector(8, T) = dx * dx + dy * dy;
+            const result: @Vector(8, T) = @sqrt(dist_sq);
+            return result;
         }
     };
 }
@@ -295,9 +300,10 @@ pub fn sliceRadiiBatch8Gen(comptime T: type) type {
             const rp_sq = r_sq - dz_sq;
 
             const zero: @Vector(8, T) = @splat(0.0);
-            const rp_sq_clamped = @max(rp_sq, zero);
+            const rp_sq_clamped: @Vector(8, T) = @max(rp_sq, zero);
 
-            return @sqrt(rp_sq_clamped);
+            const result: @Vector(8, T) = @sqrt(rp_sq_clamped);
+            return result;
         }
     };
 }


### PR DESCRIPTION
Closes #98.

## Summary

- Toolchain bump to Zig 0.16.0 (deps: zxdrfile v0.4.0, zsasa v0.2.11)
- Threads `std.Io` through the CLI ("Juicy Main") and exposes a process-global `Io.Threaded` from the C API for FFI consumers (Python)
- Migrates all `std.fs.*` call sites to `std.Io.{File,Dir}` with `io` arguments; `ArrayList.writer(allocator)` replaced by `std.Io.Writer.Allocating`
- Mechanical renames: `ArrayList{}`/`ArrayListUnmanaged{}` → `.empty`, `mem.indexOf*` → `mem.find*`, `trimLeft`/`Right` → `trimStart`/`End`
- 0.16-specific fixes for SIMD float→int conversion (`@Vector` typing in `simd/lee_richards.zig`) and macOS `vm_prot_t` packed struct (`mmap_reader.zig`)

## Test plan

- [x] `zig build` (Debug)
- [x] `zig build -Doptimize=ReleaseFast`
- [x] `zig build test` (Zig unit tests)
- [x] `cd python && uv run --with pytest --with numpy pytest tests -x -q` — 73/73 passed
- [x] `uv run --with numpy --script validation/validate.py` — 13/14 passed (1 PBC skip due to pyztraj env, not a regression)
- [x] CLI smoke (rmsd/rg) on PDB and NetCDF trajectories