### PR TITLE
release: v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.7.0] - 2026-04-26
+
+### Changed
+- #100 Migrate to Zig 0.16
+  - Bump `minimum_zig_version` 0.15.2 → 0.16.0; update CI matrix and README
+  - Bump dependencies: zxdrfile v0.2.0 → v0.4.0, zsasa v0.2.4 → v0.2.11
+  - "Juicy Main": `pub fn main(init: std.process.Init)` threads `std.Io` through CLI runners and trajectory readers/writers
+  - C API exposes a process-global `Io.Threaded` lazily (FFI/Python consumers don't need to provide an `Io`)
+  - All `std.fs.{File,Dir,cwd}` migrated to `std.Io.{File,Dir.cwd()}`; file ops now take an `io` argument
+  - DCD and NC native readers/writers now use buffered `std.Io.File.Reader`/`.Writer`
+  - `ArrayList(u8).writer(allocator)` call sites replaced with `std.Io.Writer.Allocating`
+  - 0.16-specific fixes: SIMD `@Vector(N, T)` annotations in `simd/lee_richards.zig`; darwin `vm_prot_t` packed-struct `.{ .READ = true }` in `mmap_reader.zig`
+
+### BREAKING CHANGES
+- Building from source now requires Zig 0.16.0 or later (previously 0.15.2+)
+- Zig API: `XtcReader.open`, `XtcWriter.open`, `TrrReader.open`, `TrrWriter.open`, `DcdReader.open`, `NcReader.open`, `NcWriter.open` now take `io: std.Io` as the first argument
+- Zig API: `cli/loader.loadTopology`, `loadAllFrames`, `loadAllFramesWithProgress`, `loadTrajectoryInfo` and all CLI runner functions now take `io: std.Io` as the first argument
+- The Python (pyztraj) and CLI surfaces are unchanged
+
 ## [0.6.2] - 2026-04-13
 
 ### Added

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-const version = "0.6.2";
+const version = "0.7.0";
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0x17e956260cdc6d81,
     .name = .ztraj,
-    .version = "0.6.2",
+    .version = "0.7.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .zxdrfile = .{

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyztraj"
-version = "0.6.2"
+version = "0.7.0"
 description = "Fast molecular dynamics trajectory analysis powered by Zig"
 readme = "README.md"
 license = "MIT"

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -57,7 +57,7 @@ pub const ZTRAJ_ERROR_EOF: c_int = -5;
 // Version
 // =============================================================================
 
-const VERSION: [*:0]const u8 = "0.6.2";
+const VERSION: [*:0]const u8 = "0.7.0";
 
 /// Get the library version string.
 export fn ztraj_version() callconv(.c) [*:0]const u8 {


### PR DESCRIPTION
## [0.7.0] - 2026-04-26

### Changed
- #100 Migrate to Zig 0.16
  - Bump `minimum_zig_version` 0.15.2 → 0.16.0; update CI matrix and README
  - Bump dependencies: zxdrfile v0.2.0 → v0.4.0, zsasa v0.2.4 → v0.2.11
  - "Juicy Main": `pub fn main(init: std.process.Init)` threads `std.Io` through CLI runners and trajectory readers/writers
  - C API exposes a process-global `Io.Threaded` lazily (FFI/Python consumers don't need to provide an `Io`)
  - All `std.fs.{File,Dir,cwd}` migrated to `std.Io.{File,Dir.cwd()}`; file ops now take an `io` argument
  - DCD and NC native readers/writers now use buffered `std.Io.File.Reader`/`.Writer`
  - `ArrayList(u8).writer(allocator)` call sites replaced with `std.Io.Writer.Allocating`
  - 0.16-specific fixes: SIMD `@Vector(N, T)` annotations in `simd/lee_richards.zig`; darwin `vm_prot_t` packed-struct `.{ .READ = true }` in `mmap_reader.zig`

### BREAKING CHANGES
- Building from source now requires Zig 0.16.0 or later (previously 0.15.2+)
- Zig API: `XtcReader.open`, `XtcWriter.open`, `TrrReader.open`, `TrrWriter.open`, `DcdReader.open`, `NcReader.open`, `NcWriter.open` now take `io: std.Io` as the first argument
- Zig API: `cli/loader.loadTopology`, `loadAllFrames`, `loadAllFramesWithProgress`, `loadTrajectoryInfo` and all CLI runner functions now take `io: std.Io` as the first argument
- The Python (pyztraj) and CLI surfaces are unchanged

## Test plan

- [x] `zig build` (Debug) and `-Doptimize=ReleaseFast`
- [x] `zig build test` — 231/231 passed
- [x] `./zig-out/bin/ztraj --version` reports `0.7.0`