### PR TITLE
fix(ci): bump cibuildwheel Linux Zig 0.15.2 → 0.16.0

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -61,7 +61,7 @@ test-command = "pytest {project}/python/tests -x -q"
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
-before-all = "curl -sSfL https://ziglang.org/download/0.15.2/zig-$(uname -m)-linux-0.15.2.tar.xz | tar -xJ -C /usr/local && ln -sf /usr/local/zig-$(uname -m)-linux-0.15.2/zig /usr/local/bin/zig && zig build -Doptimize=ReleaseFast"
+before-all = "curl -sSfL https://ziglang.org/download/0.16.0/zig-$(uname -m)-linux-0.16.0.tar.xz | tar -xJ -C /usr/local && ln -sf /usr/local/zig-$(uname -m)-linux-0.16.0/zig /usr/local/bin/zig && zig build -Doptimize=ReleaseFast"
 
 [tool.cibuildwheel.macos]
 before-all = "zig build -Doptimize=ReleaseFast"


### PR DESCRIPTION
## Summary

The v0.7.0 publish workflow failed on the two Linux wheel jobs because `python/pyproject.toml`'s `[tool.cibuildwheel.linux] before-all` script still hardcodes a Zig 0.15.2 download URL. The rest of the toolchain migration (CI matrix, build.zig.zon `minimum_zig_version`, `mlugg/setup-zig`) was already on 0.16.0; only this cibuildwheel hook was missed.

Update the URL and symlink path to 0.16.0 so cibuildwheel installs the matching toolchain inside the manylinux container.

## Test plan

- [x] Verified Zig 0.16.0 download URLs (x86_64 and aarch64) return HTTP 200
- [ ] Re-run publish workflow after merge by re-tagging v0.7.0 (no v0.7.0 artifacts on PyPI yet, the publish job was skipped because wheel matrix had failures)