### PR TITLE
Ignore local Zig package cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ notebooks/__marimo__/
 python/dist/
 
 .worktrees/
+zig-pkg/


### PR DESCRIPTION
## Summary

- Add `zig-pkg/` to `.gitignore` so local Zig package cache directories do not show up as untracked files.

## Validation

- `git check-ignore -v zig-pkg/`
