### PR TITLE
release: v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.8.0] - 2026-05-20
+
+### Added
+- #103 Integrate XDR trajectory I/O into ztraj
+  - Move XDR/XTC/TRR low-level implementation into `src/io/` and remove the external `zxdrfile` Zig dependency
+  - Preserve high-level `ztraj.io.xtc` and `ztraj.io.trr` reader/writer APIs
+  - Add third-party BSD 2-Clause notices to Zig and Python package distributions
+
+### Changed
+- #104 Ignore local Zig package cache
+
 ## [0.7.0] - 2026-04-26
 
 ### Changed

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-const version = "0.7.0";
+const version = "0.8.0";
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0x17e956260cdc6d81,
     .name = .ztraj,
-    .version = "0.7.0",
+    .version = "0.8.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .zsasa = .{

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyztraj"
-version = "0.7.0"
+version = "0.8.0"
 description = "Fast molecular dynamics trajectory analysis powered by Zig"
 readme = "README.md"
 license = "MIT"

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -57,7 +57,7 @@ pub const ZTRAJ_ERROR_EOF: c_int = -5;
 // Version
 // =============================================================================
 
-const VERSION: [*:0]const u8 = "0.7.0";
+const VERSION: [*:0]const u8 = "0.8.0";
 
 /// Get the library version string.
 export fn ztraj_version() callconv(.c) [*:0]const u8 {


### PR DESCRIPTION
## [v0.8.0] - 2026-05-20

### Added
- #103 Integrate XDR trajectory I/O into ztraj
  - Move XDR/XTC/TRR low-level implementation into `src/io/` and remove the external `zxdrfile` Zig dependency
  - Preserve high-level `ztraj.io.xtc` and `ztraj.io.trr` reader/writer APIs
  - Add third-party BSD 2-Clause notices to Zig and Python package distributions

### Changed
- #104 Ignore local Zig package cache

## Validation
- `zig fmt --check build.zig build.zig.zon`
- `zig build test`
- `cd python && uv run --extra dev pytest tests -x -q` — 73 passed
